### PR TITLE
Fix rate limiter token accounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ A tiny, ops-friendly Discord **webhook** announcer for Fabric servers. Plugins c
 ## Features
 - Webhook-only transport (no JDA), tiny runtime footprint
 - Shared **AnnounceBus** API for every plugin – no token sharing or HTTP boilerplate
-- Hot-reloadable routing via `mindiscord.json5`, including `env:` secrets
+- Hot-reloadable routing via `mindiscord.json5`, including `env:` secrets and per-feature toggles
 - Bounded queue with selectable overflow policy + token-bucket rate limiting per route
 - Exponential retries with 429 `Retry-After` handling and jittered backoff
 - **MinCore** ledger integration (`mindiscord` addon/op=`announce`) and optional per-route stats table
 - Operator commands: `/mindiscord routes`, `/mindiscord test`, `/mindiscord diag`
+- LuckPerms-first permission gateway (MinCore → LuckPerms → Fabric Permissions → vanilla OP)
 
 ## Requirements
 - Fabric 1.21.8 (server), Java 21
@@ -25,28 +26,49 @@ A tiny, ops-friendly Discord **webhook** announcer for Fabric servers. Plugins c
 ## Config (example)
 ```json5
 {
-  mode: "webhook",
-  routes: {
-    default:            "https://discord.com/api/webhooks/GGGG/HHH",
-    eventAnnouncements: "env:MINDISCORD_WEBHOOK_ANNOUNCE",
-    eventStarts:        "https://discord.com/api/webhooks/AAAA/BBB",
-    eventWinners:       "https://discord.com/api/webhooks/CCCC/DDD",
-    rareDrops:          "https://discord.com/api/webhooks/EEEE/FFF"
+  core: {
+    enabled: true,
+    redactUrlsInCommands: true,
+    hotReload: true
   },
-  defaults: { username: "MinDiscord", avatarUrl: "" },
-  queue: { maxSize: 2000, onOverflow: "dropOldest" },
-  retry: { maxAttempts: 6, baseDelayMs: 500, maxDelayMs: 15000, jitter: true },
-  ratelimit: { perRouteBurst: 10, perRouteRefillPerSec: 5 },
-  log: { level: "INFO", json: false }
+  routes: {
+    default: "env:DISCORD_WEBHOOK_DEFAULT",
+    eventAnnouncements: "env:DISCORD_WEBHOOK_EVENTS",
+    rareDrops: "https://discord.com/api/webhooks/RARE/DROPS"
+  },
+  announce: {
+    enabled: true,
+    allowFallbackToDefault: true,
+    allowedRoutes: ["default", "eventAnnouncements", "rareDrops"]
+  },
+  rateLimit: {
+    perRoute: {
+      default: { tokensPerMinute: 20, burst: 10 },
+      rareDrops: { tokensPerMinute: 6, burst: 3 }
+    },
+    overflowPolicy: "dropOldest"
+  },
+  queue: { capacity: 512, workerThreads: 1 },
+  transport: { connectTimeoutMs: 3000, readTimeoutMs: 5000, maxAttempts: 4 },
+  commands: {
+    routes: { enabled: true },
+    test: { enabled: true },
+    diag: { enabled: true }
+  },
+  permissions: { admin: "mindiscord.admin" }
 }
 ```
 
-### Routing & hot reload
-- `mindiscord.json5` is watched at runtime – edits are applied without rebooting.
-- Values starting with `env:` (e.g. `env:MINDISCORD_WEBHOOK_ANNOUNCE`) are resolved from the server
+### Routing, toggles & hot reload
+- `mindiscord.json5` is watched at runtime – edits are applied without rebooting unless
+  both the previous and new configs set `core.hotReload=false`.
+- `core.enabled=false` returns `DISABLED` for all commands and sends.
+- `announce.enabled=false` blocks announcement sends; `announce.allowedRoutes` restricts the set of
+  valid route names (others return `ROUTE_DISABLED`). When `allowFallbackToDefault=true`, unknown but
+  allowed routes fall back to `default` and surface `BAD_ROUTE_FALLBACK`.
+- Values starting with `env:` (e.g. `env:DISCORD_WEBHOOK_EVENTS`) are resolved from the server
   environment; missing variables result in `BAD_ROUTE` responses.
-- Unknown routes fall back to `default` (when configured) and report `BAD_ROUTE_FALLBACK` so plugins
-  can log that the fallback was used.
+- `/mindiscord routes` respects `core.redactUrlsInCommands` when showing webhook URLs.
 
 ### Queue, workers & retries
 - A single worker thread drains a bounded queue; overflow policy is configurable (`dropOldest`,
@@ -59,8 +81,8 @@ A tiny, ops-friendly Discord **webhook** announcer for Fabric servers. Plugins c
 ### Commands
 | Command | Description |
 | --- | --- |
-| `/mindiscord routes` | Lists configured routes, showing `env:` status without leaking tokens. |
-| `/mindiscord test <route> <text>` | Asynchronously sends a one-line test message via the route. |
+| `/mindiscord routes` | Lists configured routes, showing `env:` status and redacting URLs when configured. |
+| `/mindiscord test <route> <text>` | Asynchronously sends a one-line test message via the route (subject to toggles). |
 | `/mindiscord diag` | Shows queue depth and the last success/failure per route. |
 
 All commands are rate-limited (2 s per sender) and log to the MinCore ledger with reason `command`.
@@ -68,8 +90,8 @@ All commands are rate-limited (2 s per sender) and log to the MinCore ledger wit
 ### Result codes
 `SendResult.code` (and the ledger code) may be one of:
 
-`OK`, `BAD_ROUTE_FALLBACK`, `BAD_ROUTE`, `BAD_PAYLOAD`, `QUEUE_FULL`, `DISCORD_429`, `DISCORD_5XX`,
-`NETWORK_IO`, `GIVE_UP`.
+`OK`, `BAD_ROUTE_FALLBACK`, `BAD_ROUTE`, `ROUTE_DISABLED`, `BAD_PAYLOAD`, `QUEUE_FULL`, `DISCORD_429`,
+`DISCORD_5XX`, `NETWORK_IO`, `DISABLED`, `GIVE_UP`.
 
 ### Ledger & optional stats
 - Every accepted send logs to MinCore with addon `mindiscord`, op `announce`, and a compact

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@
 A tiny, ops-friendly Discord **webhook** announcer for Fabric servers. Plugins call MinDiscord’s API to post messages; no Discord libs, secrets, or HTTP code in your plugins.
 
 ## Features
-- Webhook-only transport (no JDA), minimal footprint
-- Shared **AnnounceBus** API for all plugins
-- **Routing** via `mindiscord.json5` with hot reload
-- Per-route rate limits and simple retries
-- **MinCore** integration: ledger audit lines, optional stats
-- Commands: `/mindiscord routes|test|diag`
+- Webhook-only transport (no JDA), tiny runtime footprint
+- Shared **AnnounceBus** API for every plugin – no token sharing or HTTP boilerplate
+- Hot-reloadable routing via `mindiscord.json5`, including `env:` secrets
+- Bounded queue with selectable overflow policy + token-bucket rate limiting per route
+- Exponential retries with 429 `Retry-After` handling and jittered backoff
+- **MinCore** ledger integration (`mindiscord` addon/op=`announce`) and optional per-route stats table
+- Operator commands: `/mindiscord routes`, `/mindiscord test`, `/mindiscord diag`
 
 ## Requirements
 - Fabric 1.21.8 (server), Java 21
@@ -39,6 +40,43 @@ A tiny, ops-friendly Discord **webhook** announcer for Fabric servers. Plugins c
   log: { level: "INFO", json: false }
 }
 ```
+
+### Routing & hot reload
+- `mindiscord.json5` is watched at runtime – edits are applied without rebooting.
+- Values starting with `env:` (e.g. `env:MINDISCORD_WEBHOOK_ANNOUNCE`) are resolved from the server
+  environment; missing variables result in `BAD_ROUTE` responses.
+- Unknown routes fall back to `default` (when configured) and report `BAD_ROUTE_FALLBACK` so plugins
+  can log that the fallback was used.
+
+### Queue, workers & retries
+- A single worker thread drains a bounded queue; overflow policy is configurable (`dropOldest`,
+  `dropNewest`, `reject`).
+- Rate limits are enforced per **resolved** route using a token bucket (`perRouteBurst` / `perRouteRefillPerSec`).
+- HTTP 429 honours `Retry-After`; 5xx and network errors use exponential backoff with optional jitter.
+- After `maxAttempts` the send completes with `GIVE_UP`. Every accepted send produces a MinCore ledger
+  entry and optionally increments the `mindiscord_stats` table (if MinCore’s DB is available).
+
+### Commands
+| Command | Description |
+| --- | --- |
+| `/mindiscord routes` | Lists configured routes, showing `env:` status without leaking tokens. |
+| `/mindiscord test <route> <text>` | Asynchronously sends a one-line test message via the route. |
+| `/mindiscord diag` | Shows queue depth and the last success/failure per route. |
+
+All commands are rate-limited (2 s per sender) and log to the MinCore ledger with reason `command`.
+
+### Result codes
+`SendResult.code` (and the ledger code) may be one of:
+
+`OK`, `BAD_ROUTE_FALLBACK`, `BAD_ROUTE`, `BAD_PAYLOAD`, `QUEUE_FULL`, `DISCORD_429`, `DISCORD_5XX`,
+`NETWORK_IO`, `GIVE_UP`.
+
+### Ledger & optional stats
+- Every accepted send logs to MinCore with addon `mindiscord`, op `announce`, and a compact
+  `extraJson` payload describing the resolved route, requested route, payload size, and embed count.
+- When MinCore’s extension database is available, `mindiscord_stats` (route/day counters) is
+  auto-created and updated off-thread. Failures are silently ignored so Discord delivery is never
+  blocked by the database.
 
 ## For Plugin Authors
 See **DEVELOPER_GUIDE.md** for API usage, examples, and result codes.

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
   mappings "net.fabricmc:yarn:${mappings}:v2"
   modImplementation "net.fabricmc:fabric-loader:${fabricLoaderVersion}"
   modImplementation "net.fabricmc.fabric-api:fabric-api:${fabricApiVersion}"
+  implementation 'org.hjson:hjson:3.0.0'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
   // MinCore is a hard dependency declared in fabric.mod.json and Modrinth metadata.
   // DO NOT ship MinCore inside this jar.
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ dependencies {
   modImplementation "net.fabricmc.fabric-api:fabric-api:${fabricApiVersion}"
   implementation 'org.hjson:hjson:3.0.0'
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
+  compileOnly 'net.luckperms:api:5.4'
+  compileOnly 'me.lucko:fabric-permissions-api:0.3.1'
   // MinCore is a hard dependency declared in fabric.mod.json and Modrinth metadata.
   // DO NOT ship MinCore inside this jar.
 }
@@ -68,6 +70,8 @@ loom {
 dependencies {
   testImplementation platform("org.junit:junit-bom:5.10.2")
   testImplementation "org.junit.jupiter:junit-jupiter"
+  testImplementation "org.mockito:mockito-core:5.12.0"
+  testImplementation "org.mockito:mockito-inline:5.2.0"
 }
 
 tasks.test {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,9 @@
+pluginManagement {
+  repositories {
+    gradlePluginPortal()
+    maven { url 'https://maven.fabricmc.net/' }
+    maven { url 'https://maven.minecraftforge.net/' }
+  }
+}
+
 rootProject.name = 'mindiscord'

--- a/src/main/java/dev/mindiscord/MinDiscordMod.java
+++ b/src/main/java/dev/mindiscord/MinDiscordMod.java
@@ -1,25 +1,18 @@
 package dev.mindiscord;
 
 import dev.mindiscord.api.MinDiscordApi;
-import dev.mindiscord.core.AnnounceBusImpl;
-import dev.mindiscord.core.Router;
-import dev.mindiscord.core.WebhookTransport;
-import dev.mindiscord.core.Config;
-import dev.mindiscord.core.ConfigLoader;
+import dev.mindiscord.core.MinDiscordRuntime;
 import net.fabricmc.api.ModInitializer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public final class MinDiscordMod implements ModInitializer {
+  private static final Logger LOGGER = LogManager.getLogger("MinDiscord");
+
   @Override public void onInitialize() {
-    // Load config (creates example file if missing)
-    Config cfg = ConfigLoader.loadOrCreate();
-    Router router = new Router(cfg);
-    WebhookTransport transport = new WebhookTransport();
-    AnnounceBusImpl bus = new AnnounceBusImpl(router, transport, cfg);
-
-    // Install for discovery
-    MinDiscordApi.install(bus);
-
-    dev.mindiscord.commands.CommandRegistrar.registerAll(); // stub registration
-    System.out.println("[MinDiscord] Initialized (skeleton)");
+    MinDiscordRuntime runtime = MinDiscordRuntime.init();
+    MinDiscordApi.install(runtime.bus());
+    dev.mindiscord.commands.CommandRegistrar.registerAll(runtime);
+    LOGGER.info("MinDiscord initialized");
   }
 }

--- a/src/main/java/dev/mindiscord/commands/CommandRegistrar.java
+++ b/src/main/java/dev/mindiscord/commands/CommandRegistrar.java
@@ -1,13 +1,55 @@
 package dev.mindiscord.commands;
 
-/**
- * Placeholder for command registration.
- * Intentionally avoids Fabric imports so the skeleton compiles without wiring.
- * Codex should replace this with real Fabric command registration.
- */
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import dev.mindiscord.core.MinDiscordRuntime;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+
 public final class CommandRegistrar {
-  public static void registerAll() {
-    // TODO: Register /mindiscord routes|test|diag using Fabric command API.
-    System.out.println("[MinDiscord] CommandRegistrar.registerAll() invoked (stub).");
+  private static final long COOLDOWN_MS = 2000;
+  private static final Map<Object, Long> COOLDOWNS = new ConcurrentHashMap<>();
+
+  private CommandRegistrar() {}
+
+  public static void registerAll(MinDiscordRuntime runtime) {
+    CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
+      LiteralArgumentBuilder<ServerCommandSource> root =
+          CommandManager.literal("mindiscord").requires(src -> src.hasPermissionLevel(2));
+      MindiscordRoutesCommand.register(root, runtime);
+      MindiscordTestCommand.register(root, runtime);
+      MindiscordDiagCommand.register(root, runtime);
+      dispatcher.register(root);
+    });
+  }
+
+  static boolean tryConsumeCooldown(ServerCommandSource source) {
+    Object key = source.getEntity() != null ? source.getEntity().getUuid() : CommandRegistrar.class;
+    long now = System.currentTimeMillis();
+    Long last = COOLDOWNS.get(key);
+    if (last != null && now - last < COOLDOWN_MS) {
+      long remaining = COOLDOWN_MS - (now - last);
+      source.sendError(
+          Text.literal(String.format("Mindiscord command cooldown %.1fs", remaining / 1000.0)));
+      return false;
+    }
+    COOLDOWNS.put(key, now);
+    return true;
+  }
+
+  static void logCommand(MinDiscordRuntime runtime, String command, boolean ok, String message) {
+    runtime.bridge().logLedger(
+        "command",
+        ok,
+        ok ? "OK" : "ERROR",
+        UUID.randomUUID().toString(),
+        "command",
+        command,
+        0,
+        0);
   }
 }

--- a/src/main/java/dev/mindiscord/commands/CommandRegistrar.java
+++ b/src/main/java/dev/mindiscord/commands/CommandRegistrar.java
@@ -1,13 +1,16 @@
 package dev.mindiscord.commands;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import dev.mindiscord.core.Config;
 import dev.mindiscord.core.MinDiscordRuntime;
+import dev.mindiscord.perms.Perms;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 
 public final class CommandRegistrar {
@@ -19,12 +22,22 @@ public final class CommandRegistrar {
   public static void registerAll(MinDiscordRuntime runtime) {
     CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
       LiteralArgumentBuilder<ServerCommandSource> root =
-          CommandManager.literal("mindiscord").requires(src -> src.hasPermissionLevel(2));
+          CommandManager.literal("mindiscord")
+              .requires(src -> hasAdminPermission(runtime, src));
       MindiscordRoutesCommand.register(root, runtime);
       MindiscordTestCommand.register(root, runtime);
       MindiscordDiagCommand.register(root, runtime);
       dispatcher.register(root);
     });
+  }
+
+  private static boolean hasAdminPermission(MinDiscordRuntime runtime, ServerCommandSource source) {
+    Config config = runtime.config();
+    String node = config.permissions().admin();
+    if (!(source.getEntity() instanceof ServerPlayerEntity player)) {
+      return source.hasPermissionLevel(2);
+    }
+    return Perms.check(player, node, 2);
   }
 
   static boolean tryConsumeCooldown(ServerCommandSource source) {

--- a/src/main/java/dev/mindiscord/commands/MindiscordDiagCommand.java
+++ b/src/main/java/dev/mindiscord/commands/MindiscordDiagCommand.java
@@ -2,6 +2,7 @@ package dev.mindiscord.commands;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import dev.mindiscord.core.AnnounceBusImpl;
+import dev.mindiscord.core.Config;
 import dev.mindiscord.core.MinDiscordRuntime;
 import java.time.Instant;
 import java.util.Map;
@@ -19,6 +20,17 @@ public final class MindiscordDiagCommand {
 
   private static int execute(ServerCommandSource source, MinDiscordRuntime runtime) {
     if (!CommandRegistrar.tryConsumeCooldown(source)) {
+      return 0;
+    }
+    Config cfg = runtime.config();
+    if (!cfg.core().enabled()) {
+      source.sendError(Text.literal("MinDiscord disabled via config"));
+      CommandRegistrar.logCommand(runtime, "diag", false, "DISABLED");
+      return 0;
+    }
+    if (!cfg.commands().diagEnabled()) {
+      source.sendError(Text.literal("Diag command disabled via config"));
+      CommandRegistrar.logCommand(runtime, "diag", false, "DISABLED");
       return 0;
     }
     AnnounceBusImpl.DiagnosticsSnapshot snapshot = runtime.diagnostics();

--- a/src/main/java/dev/mindiscord/commands/MindiscordDiagCommand.java
+++ b/src/main/java/dev/mindiscord/commands/MindiscordDiagCommand.java
@@ -1,5 +1,57 @@
 package dev.mindiscord.commands;
 
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import dev.mindiscord.core.AnnounceBusImpl;
+import dev.mindiscord.core.MinDiscordRuntime;
+import java.time.Instant;
+import java.util.Map;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+
 public final class MindiscordDiagCommand {
-  // TODO: wire into your command framework. This is a stub file for Codex.
+  private MindiscordDiagCommand() {}
+
+  public static void register(
+      LiteralArgumentBuilder<ServerCommandSource> root, MinDiscordRuntime runtime) {
+    root.then(CommandManager.literal("diag").executes(ctx -> execute(ctx.getSource(), runtime)));
+  }
+
+  private static int execute(ServerCommandSource source, MinDiscordRuntime runtime) {
+    if (!CommandRegistrar.tryConsumeCooldown(source)) {
+      return 0;
+    }
+    AnnounceBusImpl.DiagnosticsSnapshot snapshot = runtime.diagnostics();
+    source.sendFeedback(
+        () ->
+            Text.literal(
+                String.format(
+                    "Queue: %d/%d",
+                    snapshot.queueSize(), snapshot.queueCapacity())),
+        false);
+    if (snapshot.routes().isEmpty()) {
+      source.sendFeedback(() -> Text.literal("  (no route history yet)"), false);
+    } else {
+      for (Map.Entry<String, dev.mindiscord.core.Diagnostics.RouteSnapshot> entry :
+          snapshot.routes().entrySet()) {
+        var info = entry.getValue();
+        source.sendFeedback(
+            () ->
+                Text.literal(
+                    String.format(
+                        "  - %s | lastSuccess=%s | lastFailure=%s (%s)",
+                        entry.getKey(),
+                        formatInstant(info.lastSuccess()),
+                        formatInstant(info.lastFailure()),
+                        info.lastFailureCode() != null ? info.lastFailureCode() : "-")),
+            false);
+      }
+    }
+    CommandRegistrar.logCommand(runtime, "diag", true, null);
+    return snapshot.routes().size();
+  }
+
+  private static String formatInstant(Instant instant) {
+    return instant != null ? instant.toString() : "never";
+  }
 }

--- a/src/main/java/dev/mindiscord/commands/MindiscordRoutesCommand.java
+++ b/src/main/java/dev/mindiscord/commands/MindiscordRoutesCommand.java
@@ -1,5 +1,55 @@
 package dev.mindiscord.commands;
 
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import dev.mindiscord.core.MinDiscordRuntime;
+import dev.mindiscord.core.Router;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+
 public final class MindiscordRoutesCommand {
-  // TODO: implement: list routes and whether they come from env:
+  private MindiscordRoutesCommand() {}
+
+  public static void register(
+      LiteralArgumentBuilder<ServerCommandSource> root, MinDiscordRuntime runtime) {
+    root.then(CommandManager.literal("routes").executes(ctx -> execute(ctx.getSource(), runtime)));
+  }
+
+  private static int execute(ServerCommandSource source, MinDiscordRuntime runtime) {
+    if (!CommandRegistrar.tryConsumeCooldown(source)) {
+      return 0;
+    }
+    var routes = runtime.routes();
+    source.sendFeedback(
+        () -> Text.literal("MinDiscord routes (" + routes.size() + ")"),
+        false);
+    if (routes.isEmpty()) {
+      source.sendFeedback(() -> Text.literal("  (no routes configured)"), false);
+    } else {
+      for (Router.RouteInfo info : routes) {
+        String value;
+        if (info.environment()) {
+          value =
+              "env:" + info.envVariable() + (info.available() ? " (set)" : " (missing)");
+        } else {
+          value = redact(info.rawTarget());
+        }
+        source.sendFeedback(
+            () -> Text.literal("  - " + info.name() + ": " + value), false);
+      }
+    }
+    CommandRegistrar.logCommand(runtime, "routes", true, null);
+    return routes.size();
+  }
+
+  private static String redact(String url) {
+    if (url == null || url.isBlank()) {
+      return "unset";
+    }
+    int idx = url.indexOf("/api/webhooks/");
+    if (idx > 0) {
+      return url.substring(0, idx + "/api/webhooks/".length()) + "…";
+    }
+    return url;
+  }
 }

--- a/src/main/java/dev/mindiscord/commands/MindiscordTestCommand.java
+++ b/src/main/java/dev/mindiscord/commands/MindiscordTestCommand.java
@@ -1,5 +1,54 @@
 package dev.mindiscord.commands;
 
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import dev.mindiscord.api.SendResult;
+import dev.mindiscord.core.MinDiscordRuntime;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+
 public final class MindiscordTestCommand {
-  // TODO: implement: /mindiscord test <route> <text>
+  private MindiscordTestCommand() {}
+
+  public static void register(
+      LiteralArgumentBuilder<ServerCommandSource> root, MinDiscordRuntime runtime) {
+    root.then(CommandManager.literal("test")
+        .then(CommandManager.argument("route", StringArgumentType.string())
+            .then(CommandManager.argument("text", StringArgumentType.greedyString())
+                .executes(ctx -> execute(ctx.getSource(), runtime,
+                    StringArgumentType.getString(ctx, "route"),
+                    StringArgumentType.getString(ctx, "text"))))));
+  }
+
+  private static int execute(
+      ServerCommandSource source, MinDiscordRuntime runtime, String route, String text) {
+    if (!CommandRegistrar.tryConsumeCooldown(source)) {
+      return 0;
+    }
+    source.sendFeedback(() -> Text.literal("Dispatching test message…"), false);
+    CompletableFuture<SendResult> future = runtime.bus().send(route, text);
+    future.whenComplete((result, error) -> {
+      if (error != null) {
+        source.sendError(Text.literal("Test send failed: " + error.getMessage()));
+        CommandRegistrar.logCommand(runtime, "test", false, error.getMessage());
+      } else {
+        if (result.ok()) {
+          source.sendFeedback(
+              () -> Text.literal(
+                  "Sent (" + result.code() + "): " + Objects.requireNonNullElse(result.message(), "")),
+              false);
+        } else {
+          source.sendError(
+              Text.literal(
+                  "Send failed (" + result.code() + "): "
+                      + Objects.requireNonNullElse(result.message(), "")));
+        }
+        CommandRegistrar.logCommand(runtime, "test", result.ok(), result.code());
+      }
+    });
+    return 1;
+  }
 }

--- a/src/main/java/dev/mindiscord/commands/MindiscordTestCommand.java
+++ b/src/main/java/dev/mindiscord/commands/MindiscordTestCommand.java
@@ -3,6 +3,7 @@ package dev.mindiscord.commands;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import dev.mindiscord.api.SendResult;
+import dev.mindiscord.core.Config;
 import dev.mindiscord.core.MinDiscordRuntime;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -26,6 +27,27 @@ public final class MindiscordTestCommand {
   private static int execute(
       ServerCommandSource source, MinDiscordRuntime runtime, String route, String text) {
     if (!CommandRegistrar.tryConsumeCooldown(source)) {
+      return 0;
+    }
+    Config cfg = runtime.config();
+    if (!cfg.core().enabled()) {
+      source.sendError(Text.literal("MinDiscord disabled via config"));
+      CommandRegistrar.logCommand(runtime, "test", false, "DISABLED");
+      return 0;
+    }
+    if (!cfg.commands().testEnabled()) {
+      source.sendError(Text.literal("Test command disabled via config"));
+      CommandRegistrar.logCommand(runtime, "test", false, "DISABLED");
+      return 0;
+    }
+    if (!cfg.announce().enabled()) {
+      source.sendError(Text.literal("Announcements disabled via config"));
+      CommandRegistrar.logCommand(runtime, "test", false, "DISABLED");
+      return 0;
+    }
+    if (!cfg.announce().isRouteAllowed(route)) {
+      source.sendError(Text.literal("Route not allowed by configuration"));
+      CommandRegistrar.logCommand(runtime, "test", false, "ROUTE_DISABLED");
       return 0;
     }
     source.sendFeedback(() -> Text.literal("Dispatching test message…"), false);

--- a/src/main/java/dev/mindiscord/core/AnnounceBusImpl.java
+++ b/src/main/java/dev/mindiscord/core/AnnounceBusImpl.java
@@ -1,51 +1,494 @@
 package dev.mindiscord.core;
 
-import dev.mindiscord.api.*;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.mindiscord.api.AllowedMentions;
+import dev.mindiscord.api.AnnounceBus;
+import dev.mindiscord.api.Embed;
+import dev.mindiscord.api.SendResult;
+import dev.mindiscord.api.WebhookMessage;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-public final class AnnounceBusImpl implements AnnounceBus {
+public final class AnnounceBusImpl implements AnnounceBus, AutoCloseable {
+  private static final Logger LOGGER = LogManager.getLogger("MinDiscord/AnnounceBus");
+  private static final ObjectMapper JSON =
+      new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
   private final Router router;
-  private final WebhookTransport transport;
-  @SuppressWarnings("unused") private final Config cfg;
+  private final DispatchQueue queue;
+  private final WebhookClient transport;
+  private final RateLimiterRegistry rateLimiter;
+  private final StatsStore statsStore;
+  private final MinCoreBridge bridge;
+  private final TimeSource timeSource;
+  private final Sleeper sleeper;
+  private final Diagnostics diagnostics = new Diagnostics();
+  private final SendWorker worker;
+  private final Thread workerThread;
+  private final AtomicBoolean closed = new AtomicBoolean();
 
-  public AnnounceBusImpl(Router router, WebhookTransport transport, Config cfg) {
-    this.router = router; this.transport = transport; this.cfg = cfg;
+  private volatile Config config;
+
+  public AnnounceBusImpl(
+      Router router,
+      DispatchQueue queue,
+      WebhookClient transport,
+      RateLimiterRegistry rateLimiter,
+      StatsStore statsStore,
+      MinCoreBridge bridge,
+      TimeSource timeSource,
+      Sleeper sleeper,
+      Config initialConfig) {
+    this.router = router;
+    this.queue = queue;
+    this.transport = transport;
+    this.rateLimiter = rateLimiter;
+    this.statsStore = statsStore;
+    this.bridge = bridge;
+    this.timeSource = timeSource;
+    this.sleeper = sleeper;
+    this.worker = new SendWorker();
+    applyConfig(initialConfig);
+    this.workerThread = new Thread(worker, "MinDiscord-Worker");
+    this.workerThread.setDaemon(true);
+    this.workerThread.start();
   }
 
-  @Override public CompletableFuture<SendResult> send(String route, String content) {
-    return send(route, messageFor(content));
+  public void applyConfig(Config config) {
+    Objects.requireNonNull(config, "config");
+    this.config = config;
+    router.update(config);
+    queue.configure(config.queue().maxSize(), config.queue().onOverflow());
+    rateLimiter.configure(config.ratelimit().perRouteBurst(), config.ratelimit().perRouteRefillPerSec());
+    worker.updateRetry(config.retry());
   }
 
-  @Override public CompletableFuture<SendResult> send(String route, WebhookMessage msg) {
-    String url = router.resolve(route);
-    String json = toJson(msg);
-    String reqId = UUID.randomUUID().toString();
-    boolean ok = url != null && transport.postJson(url, json);
-    return CompletableFuture.completedFuture(new SendResult(ok, ok ? "OK" : "NETWORK_IO", ok ? "sent" : "failed", reqId));
+  @Override
+  public CompletableFuture<SendResult> send(String route, String content) {
+    WebhookMessage msg = new WebhookMessage();
+    msg.content = content;
+    return send(route, msg);
   }
 
-  @Override public CompletableFuture<SendResult> send(String route, Embed embed) {
-    WebhookMessage m = new WebhookMessage();
-    m.embeds = java.util.List.of(embed);
-    return send(route, m);
-  }
-
-  private static WebhookMessage messageFor(String content) {
-    WebhookMessage m = new WebhookMessage(); m.content = content; return m;
-  }
-
-  // Trivial JSON builder to avoid dependencies; plugins can send complex embeds if needed
-  private static String toJson(WebhookMessage m) {
-    StringBuilder sb = new StringBuilder(); sb.append('{');
-    if (m.content != null) {
-      sb.append(""content":").append(quote(m.content));
+  @Override
+  public CompletableFuture<SendResult> send(String route, WebhookMessage message) {
+    Objects.requireNonNull(message, "message");
+    if (closed.get()) {
+      return CompletableFuture.completedFuture(
+          new SendResult(false, "GIVE_UP", "MinDiscord shutting down", UUID.randomUUID().toString()));
     }
-    sb.append('}');
-    return sb.toString();
+    Config cfg = this.config;
+    WebhookMessage normalized = normalize(message, cfg.defaults());
+    String validationError = validate(normalized);
+    UUID requestId = UUID.randomUUID();
+    if (validationError != null) {
+      return CompletableFuture.completedFuture(
+          new SendResult(false, "BAD_PAYLOAD", validationError, requestId.toString()));
+    }
+    Router.RouteResolution resolution = router.resolve(route);
+    if (!resolution.ok()) {
+      String code = resolution.status() == Router.Status.ENV_MISSING ? "BAD_ROUTE" : "BAD_ROUTE";
+      String messageText =
+          resolution.status() == Router.Status.ENV_MISSING
+              ? "Route " + resolution.resolvedRoute() + " missing env:" + resolution.envVariable()
+              : "Unknown route: " + resolution.requestedRoute();
+      return CompletableFuture.completedFuture(
+          new SendResult(false, code, messageText, requestId.toString()));
+    }
+    String json;
+    int payloadBytes;
+    int embedCount = normalized.embeds != null ? normalized.embeds.size() : 0;
+    try {
+      json = buildPayload(normalized);
+      payloadBytes = json.getBytes(StandardCharsets.UTF_8).length;
+    } catch (Exception e) {
+      return CompletableFuture.completedFuture(
+          new SendResult(false, "BAD_PAYLOAD", "Failed to encode payload", requestId.toString()));
+    }
+    CompletableFuture<SendResult> future = new CompletableFuture<>();
+    PendingRequest pending =
+        new PendingRequest(
+            requestId,
+            resolution,
+            json,
+            payloadBytes,
+            embedCount,
+            future,
+            timeSource.now());
+    DispatchQueue.QueuePushResult push = queue.enqueue(pending);
+    if (!push.isEnqueued()) {
+      future.complete(new SendResult(false, "QUEUE_FULL", "Queue full", requestId.toString()));
+      return future;
+    }
+    PendingRequest dropped = push.dropped();
+    if (dropped != null) {
+      dropped.completeQueueFull();
+    }
+    return future;
   }
 
-  private static String quote(String s) {
-    return """ + s.replace("\", "\\").replace(""", "\"") + """;
+  @Override
+  public CompletableFuture<SendResult> send(String route, Embed embed) {
+    Objects.requireNonNull(embed, "embed");
+    WebhookMessage msg = new WebhookMessage();
+    msg.embeds = List.of(embed);
+    return send(route, msg);
+  }
+
+  public DiagnosticsSnapshot diagnostics() {
+    Config cfg = this.config;
+    return new DiagnosticsSnapshot(queue.size(), cfg.queue().maxSize(), Map.copyOf(diagnostics.snapshot()));
+  }
+
+  public List<Router.RouteInfo> routes() { return new ArrayList<>(router.snapshot()); }
+
+  @Override
+  public void close() {
+    if (closed.compareAndSet(false, true)) {
+      worker.stop();
+      queue.close();
+      workerThread.interrupt();
+      try {
+        workerThread.join(2000);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
     }
+  }
+
+  private static WebhookMessage normalize(WebhookMessage original, Config.Defaults defaults) {
+    WebhookMessage copy = copyOf(original);
+    if (copy.username == null || copy.username.isBlank()) {
+      copy.username = defaults.username();
+    }
+    if ((copy.avatarUrl == null || copy.avatarUrl.isBlank()) && !defaults.avatarUrl().isBlank()) {
+      copy.avatarUrl = defaults.avatarUrl();
+    }
+    return copy;
+  }
+
+  private static WebhookMessage copyOf(WebhookMessage original) {
+    WebhookMessage copy = new WebhookMessage();
+    copy.username = original.username;
+    copy.avatarUrl = original.avatarUrl;
+    copy.content = original.content;
+    if (original.embeds != null) {
+      copy.embeds = new ArrayList<>(original.embeds);
+    }
+    copy.allowedMentions = original.allowedMentions;
+    return copy;
+  }
+
+  private static String validate(WebhookMessage message) {
+    if ((message.content == null || message.content.isBlank())
+        && (message.embeds == null || message.embeds.isEmpty())) {
+      return "Content or embeds required";
+    }
+    if (message.content != null && message.content.length() > 2000) {
+      return "Content exceeds 2000 characters";
+    }
+    if (message.username != null && message.username.length() > 80) {
+      return "Username exceeds 80 characters";
+    }
+    if (message.embeds != null) {
+      if (message.embeds.size() > 10) {
+        return "Too many embeds (max 10)";
+      }
+      for (Embed embed : message.embeds) {
+        String err = validateEmbed(embed);
+        if (err != null) {
+          return err;
+        }
+      }
+    }
+    return null;
+  }
+
+  private static String validateEmbed(Embed embed) {
+    if (embed == null) {
+      return "Embed cannot be null";
+    }
+    if (embed.title != null && embed.title.length() > 256) {
+      return "Embed title too long";
+    }
+    if (embed.description != null && embed.description.length() > 4096) {
+      return "Embed description too long";
+    }
+    if (embed.footer != null && embed.footer.text != null && embed.footer.text.length() > 2048) {
+      return "Embed footer text too long";
+    }
+    if (embed.author != null && embed.author.name != null && embed.author.name.length() > 256) {
+      return "Embed author name too long";
+    }
+    if (embed.fields != null) {
+      if (embed.fields.size() > 25) {
+        return "Embed has too many fields";
+      }
+      for (Embed.Field field : embed.fields) {
+        if (field.name != null && field.name.length() > 256) {
+          return "Embed field name too long";
+        }
+        if (field.value != null && field.value.length() > 1024) {
+          return "Embed field value too long";
+        }
+      }
+    }
+    return null;
+  }
+
+  private static String buildPayload(WebhookMessage message) throws Exception {
+    ObjectNode root = JSON.createObjectNode();
+    if (message.username != null && !message.username.isBlank()) {
+      root.put("username", message.username);
+    }
+    if (message.avatarUrl != null && !message.avatarUrl.isBlank()) {
+      root.put("avatar_url", message.avatarUrl);
+    }
+    if (message.content != null) {
+      root.put("content", message.content);
+    }
+    if (message.embeds != null && !message.embeds.isEmpty()) {
+      ArrayNode arr = root.putArray("embeds");
+      for (Embed embed : message.embeds) {
+        arr.add(serializeEmbed(embed));
+      }
+    }
+    if (message.allowedMentions != null) {
+      ObjectNode allowed = serializeAllowedMentions(message.allowedMentions);
+      if (allowed != null) {
+        root.set("allowed_mentions", allowed);
+      }
+    }
+    return JSON.writeValueAsString(root);
+  }
+
+  private static ObjectNode serializeEmbed(Embed embed) {
+    ObjectNode node = JSON.createObjectNode();
+    if (embed.title != null) node.put("title", embed.title);
+    if (embed.description != null) node.put("description", embed.description);
+    if (embed.url != null) node.put("url", embed.url);
+    if (embed.color != null) node.put("color", embed.color);
+    if (embed.author != null) {
+      ObjectNode author = JSON.createObjectNode();
+      if (embed.author.name != null) author.put("name", embed.author.name);
+      if (embed.author.url != null) author.put("url", embed.author.url);
+      if (embed.author.iconUrl != null) author.put("icon_url", embed.author.iconUrl);
+      node.set("author", author);
+    }
+    if (embed.footer != null) {
+      ObjectNode footer = JSON.createObjectNode();
+      if (embed.footer.text != null) footer.put("text", embed.footer.text);
+      if (embed.footer.iconUrl != null) footer.put("icon_url", embed.footer.iconUrl);
+      node.set("footer", footer);
+    }
+    if (embed.thumbnail != null && embed.thumbnail.url != null) {
+      ObjectNode thumb = JSON.createObjectNode();
+      thumb.put("url", embed.thumbnail.url);
+      node.set("thumbnail", thumb);
+    }
+    if (embed.image != null && embed.image.url != null) {
+      ObjectNode img = JSON.createObjectNode();
+      img.put("url", embed.image.url);
+      node.set("image", img);
+    }
+    if (embed.fields != null && !embed.fields.isEmpty()) {
+      ArrayNode fields = node.putArray("fields");
+      for (Embed.Field field : embed.fields) {
+        ObjectNode fn = JSON.createObjectNode();
+        if (field.name != null) fn.put("name", field.name);
+        if (field.value != null) fn.put("value", field.value);
+        fn.put("inline", field.inline);
+        fields.add(fn);
+      }
+    }
+    return node;
+  }
+
+  private static ObjectNode serializeAllowedMentions(AllowedMentions mentions) {
+    ObjectNode node = JSON.createObjectNode();
+    ArrayNode parse = JSON.createArrayNode();
+    if (mentions.parseEveryone) parse.add("everyone");
+    if (mentions.parseRoles) parse.add("roles");
+    if (mentions.parseUsers) parse.add("users");
+    if (!parse.isEmpty()) {
+      node.set("parse", parse);
+    }
+    if (mentions.roles != null && !mentions.roles.isEmpty()) {
+      ArrayNode roles = node.putArray("roles");
+      mentions.roles.forEach(roles::add);
+    }
+    if (mentions.users != null && !mentions.users.isEmpty()) {
+      ArrayNode users = node.putArray("users");
+      mentions.users.forEach(users::add);
+    }
+    return node.isEmpty() ? null : node;
+  }
+
+  public record DiagnosticsSnapshot(
+      int queueSize, int queueCapacity, Map<String, Diagnostics.RouteSnapshot> routes) {}
+
+  private final class SendWorker implements Runnable {
+    private volatile boolean running = true;
+    private volatile Config.Retry retry = Config.Retry.DEFAULTS;
+
+    void updateRetry(Config.Retry retry) { this.retry = retry; }
+
+    void stop() { running = false; }
+
+    @Override
+    public void run() {
+      while (running && !Thread.currentThread().isInterrupted()) {
+        PendingRequest request;
+        try {
+          request = queue.take();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          break;
+        }
+        if (request == null) {
+          continue;
+        }
+        process(request);
+      }
+    }
+
+    private void process(PendingRequest request) {
+      try {
+        String rateKey = request.resolvedRoute != null ? request.resolvedRoute : "default";
+        Duration wait = rateLimiter.acquire(rateKey, timeSource);
+        if (!wait.isZero()) {
+          sleeper.sleep(wait);
+        }
+        DeliveryResult result = deliver(request, retry);
+        request.future.complete(result.result());
+        if (result.success()) {
+          diagnostics.recordSuccess(request.resolvedRoute, timeSource.now(), result.result().message());
+        } else {
+          diagnostics.recordFailure(
+              request.resolvedRoute != null ? request.resolvedRoute : "unknown",
+              timeSource.now(),
+              result.result().code(),
+              result.result().message());
+        }
+        if (request.resolvedRoute != null) {
+          statsStore.record(request.resolvedRoute, result.success());
+        }
+        String requested = request.requestedRoute;
+        String extraRequested = Objects.equals(request.resolvedRoute, requested) ? null : requested;
+        bridge.logLedger(
+            request.resolvedRoute != null ? request.resolvedRoute : "unknown",
+            result.success(),
+            result.result().code(),
+            request.requestId.toString(),
+            request.resolvedRoute,
+            extraRequested,
+            request.payloadBytes,
+            request.embedCount);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        request.future.complete(
+            new SendResult(false, "GIVE_UP", "Interrupted", request.requestId.toString()));
+      } catch (Exception e) {
+        LOGGER.error("Worker failed: {}", e.toString());
+        request.future.complete(
+            new SendResult(false, "GIVE_UP", "Worker failure", request.requestId.toString()));
+      }
+    }
+
+    private DeliveryResult deliver(PendingRequest request, Config.Retry retry) throws InterruptedException {
+      Duration delay = retry.baseDelay();
+      int attempts = retry.maxAttempts();
+      String lastCode = null;
+      String lastMessage = null;
+      for (int attempt = 1; attempt <= attempts; attempt++) {
+        WebhookTransport.TransportResponse response = transport.postJson(request.url, request.jsonPayload);
+        if (response.success()) {
+          String code = request.fallback ? "BAD_ROUTE_FALLBACK" : "OK";
+          String msg =
+              request.fallback
+                  ? "Sent via " + request.resolvedRoute + " (fallback)"
+                  : "Sent";
+          return DeliveryResult.success(new SendResult(true, code, msg, request.requestId.toString()));
+        }
+        int status = response.statusCode();
+        if (status == 429) {
+          lastCode = "DISCORD_429";
+          lastMessage = "Discord returned 429";
+          if (attempt >= attempts) {
+            break;
+          }
+          Duration wait = response.retryAfter();
+          if (wait == null || wait.isZero() || wait.isNegative()) {
+            wait = applyJitter(delay, retry);
+          }
+          sleeper.sleep(wait);
+          delay = nextDelay(delay, retry);
+          continue;
+        }
+        if (status >= 500 || status == -1) {
+          lastCode = status >= 500 ? "DISCORD_5XX" : "NETWORK_IO";
+          lastMessage =
+              status >= 500
+                  ? "Discord returned " + status
+                  : (response.error() != null ? response.error().getMessage() : "Network error");
+          if (attempt >= attempts) {
+            break;
+          }
+          sleeper.sleep(applyJitter(delay, retry));
+          delay = nextDelay(delay, retry);
+          continue;
+        }
+        if (status >= 400) {
+          lastCode = "BAD_PAYLOAD";
+          lastMessage = "Discord rejected payload (HTTP " + status + ")";
+          return DeliveryResult.failure(
+              new SendResult(false, lastCode, lastMessage, request.requestId.toString()));
+        }
+        lastCode = "NETWORK_IO";
+        lastMessage = "Unexpected transport failure";
+      }
+      String message =
+          String.format(
+              "Retries exhausted after %d attempts (last=%s)",
+              retry.maxAttempts(),
+              lastCode != null ? lastCode : "unknown");
+      return DeliveryResult.failure(new SendResult(false, "GIVE_UP", message, request.requestId.toString()));
+    }
+
+    private Duration nextDelay(Duration current, Config.Retry retry) {
+      long currentMs = Math.max(1, current.toMillis());
+      long doubled = Math.min(retry.maxDelay().toMillis(), currentMs * 2);
+      return Duration.ofMillis(doubled);
+    }
+
+    private Duration applyJitter(Duration delay, Config.Retry retry) {
+      if (!retry.jitter()) {
+        return delay;
+      }
+      double factor = ThreadLocalRandom.current().nextDouble(0.5, 1.5);
+      long millis = Math.max(1, Math.round(delay.toMillis() * factor));
+      long clamped = Math.min(retry.maxDelay().toMillis(), millis);
+      return Duration.ofMillis(clamped);
+    }
+  }
+
+  private record DeliveryResult(SendResult result, boolean success) {
+    static DeliveryResult success(SendResult result) { return new DeliveryResult(result, true); }
+
+    static DeliveryResult failure(SendResult result) { return new DeliveryResult(result, false); }
+  }
 }

--- a/src/main/java/dev/mindiscord/core/Config.java
+++ b/src/main/java/dev/mindiscord/core/Config.java
@@ -1,19 +1,374 @@
 package dev.mindiscord.core;
 
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
+/** Immutable runtime configuration for MinDiscord. */
 public final class Config {
-  public Map<String,String> routes = new LinkedHashMap<>();
-  public Defaults defaults = new Defaults();
-  public Queue queue = new Queue();
-  public Retry retry = new Retry();
-  public RateLimit ratelimit = new RateLimit();
-  public Log log = new Log();
+  private final String mode;
+  private final Map<String, RouteDefinition> routes;
+  private final Defaults defaults;
+  private final Queue queue;
+  private final Retry retry;
+  private final RateLimit ratelimit;
+  private final Log log;
 
-  public static final class Defaults { public String username = "MinDiscord"; public String avatarUrl = ""; }
-  public static final class Queue { public int maxSize = 2000; public String onOverflow = "dropOldest"; }
-  public static final class Retry { public int maxAttempts = 6; public int baseDelayMs = 500; public int maxDelayMs = 15000; public boolean jitter = true; }
-  public static final class RateLimit { public int perRouteBurst = 10; public int perRouteRefillPerSec = 5; }
-  public static final class Log { public String level = "INFO"; public boolean json = false; }
+  private Config(
+      String mode,
+      Map<String, RouteDefinition> routes,
+      Defaults defaults,
+      Queue queue,
+      Retry retry,
+      RateLimit ratelimit,
+      Log log) {
+    this.mode = mode;
+    this.routes = routes;
+    this.defaults = defaults;
+    this.queue = queue;
+    this.retry = retry;
+    this.ratelimit = ratelimit;
+    this.log = log;
+  }
+
+  public String mode() { return mode; }
+
+  public Map<String, RouteDefinition> routes() { return routes; }
+
+  public Defaults defaults() { return defaults; }
+
+  public Queue queue() { return queue; }
+
+  public Retry retry() { return retry; }
+
+  public RateLimit ratelimit() { return ratelimit; }
+
+  public Log log() { return log; }
+
+  public static Builder builder() { return new Builder(); }
+
+  public static Config defaultConfig() { return builder().build(); }
+
+  public static final class Builder {
+    private String mode = "webhook";
+    private final Map<String, RouteDefinition> routes = new LinkedHashMap<>();
+    private Defaults defaults = Defaults.DEFAULTS;
+    private Queue queue = Queue.DEFAULTS;
+    private Retry retry = Retry.DEFAULTS;
+    private RateLimit ratelimit = RateLimit.DEFAULTS;
+    private Log log = Log.DEFAULTS;
+
+    public Builder mode(String mode) {
+      this.mode = Objects.requireNonNull(mode, "mode");
+      return this;
+    }
+
+    public Builder putRoute(String name, String target) {
+      routes.put(name, RouteDefinition.of(name, target));
+      return this;
+    }
+
+    public Builder routes(Map<String, String> map) {
+      routes.clear();
+      map.forEach(this::putRoute);
+      return this;
+    }
+
+    public Builder defaults(Defaults defaults) {
+      this.defaults = Objects.requireNonNull(defaults, "defaults");
+      return this;
+    }
+
+    public Builder queue(Queue queue) {
+      this.queue = Objects.requireNonNull(queue, "queue");
+      return this;
+    }
+
+    public Builder retry(Retry retry) {
+      this.retry = Objects.requireNonNull(retry, "retry");
+      return this;
+    }
+
+    public Builder ratelimit(RateLimit ratelimit) {
+      this.ratelimit = Objects.requireNonNull(ratelimit, "ratelimit");
+      return this;
+    }
+
+    public Builder log(Log log) {
+      this.log = Objects.requireNonNull(log, "log");
+      return this;
+    }
+
+    public Config build() {
+      String normalizedMode = Objects.requireNonNullElse(mode, "webhook");
+      if (!"webhook".equalsIgnoreCase(normalizedMode)) {
+        throw new IllegalArgumentException("Only webhook mode is supported");
+      }
+      return new Config(
+          normalizedMode.toLowerCase(Locale.ROOT),
+          Map.copyOf(routes),
+          defaults,
+          queue,
+          retry,
+          ratelimit,
+          log);
+    }
+  }
+
+  public static final class RouteDefinition {
+    private final String name;
+    private final String rawTarget;
+    private final boolean environment;
+    private final String envVariable;
+
+    private RouteDefinition(String name, String rawTarget, boolean environment, String envVariable) {
+      this.name = name;
+      this.rawTarget = rawTarget;
+      this.environment = environment;
+      this.envVariable = envVariable;
+    }
+
+    public String name() { return name; }
+
+    public String rawTarget() { return rawTarget; }
+
+    public boolean environment() { return environment; }
+
+    public String envVariable() { return envVariable; }
+
+    public static RouteDefinition of(String name, String target) {
+      Objects.requireNonNull(name, "name");
+      Objects.requireNonNull(target, "target");
+      String trimmed = target.trim();
+      if (trimmed.isEmpty()) {
+        throw new IllegalArgumentException("Route target may not be blank");
+      }
+      if (trimmed.regionMatches(true, 0, "env:", 0, 4)) {
+        String env = trimmed.substring(4).trim();
+        if (env.isEmpty()) {
+          throw new IllegalArgumentException("env: routes must specify a variable name");
+        }
+        return new RouteDefinition(name, trimmed, true, env);
+      }
+      return new RouteDefinition(name, trimmed, false, null);
+    }
+  }
+
+  public static final class Defaults {
+    static final Defaults DEFAULTS = new Defaults("MinDiscord", "");
+    private final String username;
+    private final String avatarUrl;
+
+    public Defaults(String username, String avatarUrl) {
+      this.username = Objects.requireNonNullElse(username, "MinDiscord");
+      this.avatarUrl = Objects.requireNonNullElse(avatarUrl, "");
+    }
+
+    public String username() { return username; }
+
+    public String avatarUrl() { return avatarUrl; }
+  }
+
+  public enum QueueOverflowPolicy {
+    DROP_OLDEST,
+    DROP_NEWEST,
+    REJECT;
+
+    static QueueOverflowPolicy from(String raw) {
+      if (raw == null) {
+        return DROP_OLDEST;
+      }
+      return switch (raw.toLowerCase(Locale.ROOT)) {
+        case "dropoldest" -> DROP_OLDEST;
+        case "dropnewest" -> DROP_NEWEST;
+        case "reject" -> REJECT;
+        default -> throw new IllegalArgumentException("Unknown queue policy: " + raw);
+      };
+    }
+  }
+
+  public static final class Queue {
+    static final Queue DEFAULTS = new Queue(2000, QueueOverflowPolicy.DROP_OLDEST);
+    private final int maxSize;
+    private final QueueOverflowPolicy onOverflow;
+
+    public Queue(int maxSize, QueueOverflowPolicy onOverflow) {
+      if (maxSize <= 0) {
+        throw new IllegalArgumentException("queue.maxSize must be > 0");
+      }
+      this.maxSize = maxSize;
+      this.onOverflow = Objects.requireNonNull(onOverflow, "onOverflow");
+    }
+
+    public int maxSize() { return maxSize; }
+
+    public QueueOverflowPolicy onOverflow() { return onOverflow; }
+  }
+
+  public static final class Retry {
+    static final Retry DEFAULTS =
+        new Retry(6, Duration.ofMillis(500), Duration.ofMillis(15_000), true);
+    private final int maxAttempts;
+    private final Duration baseDelay;
+    private final Duration maxDelay;
+    private final boolean jitter;
+
+    public Retry(int maxAttempts, Duration baseDelay, Duration maxDelay, boolean jitter) {
+      if (maxAttempts <= 0) {
+        throw new IllegalArgumentException("retry.maxAttempts must be > 0");
+      }
+      this.maxAttempts = maxAttempts;
+      this.baseDelay = Objects.requireNonNull(baseDelay, "baseDelay");
+      this.maxDelay = Objects.requireNonNull(maxDelay, "maxDelay");
+      this.jitter = jitter;
+    }
+
+    public int maxAttempts() { return maxAttempts; }
+
+    public Duration baseDelay() { return baseDelay; }
+
+    public Duration maxDelay() { return maxDelay; }
+
+    public boolean jitter() { return jitter; }
+  }
+
+  public static final class RateLimit {
+    static final RateLimit DEFAULTS = new RateLimit(10, 5);
+    private final int perRouteBurst;
+    private final int perRouteRefillPerSec;
+
+    public RateLimit(int perRouteBurst, int perRouteRefillPerSec) {
+      if (perRouteBurst <= 0) {
+        throw new IllegalArgumentException("ratelimit.perRouteBurst must be > 0");
+      }
+      if (perRouteRefillPerSec <= 0) {
+        throw new IllegalArgumentException("ratelimit.perRouteRefillPerSec must be > 0");
+      }
+      this.perRouteBurst = perRouteBurst;
+      this.perRouteRefillPerSec = perRouteRefillPerSec;
+    }
+
+    public int perRouteBurst() { return perRouteBurst; }
+
+    public int perRouteRefillPerSec() { return perRouteRefillPerSec; }
+  }
+
+  public static final class Log {
+    static final Log DEFAULTS = new Log("INFO", false);
+    private final String level;
+    private final boolean json;
+
+    public Log(String level, boolean json) {
+      this.level = Objects.requireNonNullElse(level, "INFO");
+      this.json = json;
+    }
+
+    public String level() { return level; }
+
+    public boolean json() { return json; }
+  }
+
+  public static Config fromRaw(Raw raw) {
+    if (raw == null) {
+      return defaultConfig();
+    }
+    Builder builder = builder();
+    if (raw.mode != null) {
+      builder.mode(raw.mode);
+    }
+    if (raw.routes != null) {
+      for (Map.Entry<String, String> entry : raw.routes.entrySet()) {
+        builder.putRoute(entry.getKey(), entry.getValue());
+      }
+    }
+    builder.defaults(raw.defaults != null ? raw.defaults.toDefaults() : Defaults.DEFAULTS);
+    builder.queue(raw.queue != null ? raw.queue.toQueue() : Queue.DEFAULTS);
+    builder.retry(raw.retry != null ? raw.retry.toRetry() : Retry.DEFAULTS);
+    builder.ratelimit(raw.ratelimit != null ? raw.ratelimit.toRateLimit() : RateLimit.DEFAULTS);
+    builder.log(raw.log != null ? raw.log.toLog() : Log.DEFAULTS);
+    return builder.build();
+  }
+
+  public static final class Raw {
+    public String mode;
+    public Map<String, String> routes;
+    public RawDefaults defaults;
+    public RawQueue queue;
+    public RawRetry retry;
+    public RawRateLimit ratelimit;
+    public RawLog log;
+  }
+
+  public static final class RawDefaults {
+    public String username;
+    public String avatarUrl;
+
+    Defaults toDefaults() { return new Defaults(username, avatarUrl); }
+  }
+
+  public static final class RawQueue {
+    public Integer maxSize;
+    public String onOverflow;
+
+    Queue toQueue() {
+      int size = maxSize != null ? maxSize : Queue.DEFAULTS.maxSize();
+      QueueOverflowPolicy policy = QueueOverflowPolicy.from(onOverflow);
+      return new Queue(size, policy);
+    }
+  }
+
+  public static final class RawRetry {
+    public Integer maxAttempts;
+    public Integer baseDelayMs;
+    public Integer maxDelayMs;
+    public Boolean jitter;
+
+    Retry toRetry() {
+      int attempts = maxAttempts != null ? maxAttempts : Retry.DEFAULTS.maxAttempts();
+      Duration base =
+          Duration.ofMillis(baseDelayMs != null ? baseDelayMs : Retry.DEFAULTS.baseDelay().toMillis());
+      Duration max =
+          Duration.ofMillis(maxDelayMs != null ? maxDelayMs : Retry.DEFAULTS.maxDelay().toMillis());
+      boolean useJitter = jitter != null ? jitter : Retry.DEFAULTS.jitter();
+      if (base.isZero() || base.isNegative()) {
+        throw new IllegalArgumentException("retry.baseDelayMs must be > 0");
+      }
+      if (max.compareTo(base) < 0) {
+        throw new IllegalArgumentException("retry.maxDelayMs must be >= baseDelayMs");
+      }
+      return new Retry(attempts, base, max, useJitter);
+    }
+  }
+
+  public static final class RawRateLimit {
+    public Integer perRouteBurst;
+    public Integer perRouteRefillPerSec;
+
+    RateLimit toRateLimit() {
+      int burst =
+          perRouteBurst != null ? perRouteBurst : RateLimit.DEFAULTS.perRouteBurst();
+      int refill =
+          perRouteRefillPerSec != null
+              ? perRouteRefillPerSec
+              : RateLimit.DEFAULTS.perRouteRefillPerSec();
+      return new RateLimit(burst, refill);
+    }
+  }
+
+  public static final class RawLog {
+    public String level;
+    public Boolean json;
+
+    Log toLog() {
+      return new Log(level, json != null ? json : Log.DEFAULTS.json());
+    }
+  }
+
+  public List<RouteDefinition> orderedRoutes() {
+    return new ArrayList<>(routes.values());
+  }
 }

--- a/src/main/java/dev/mindiscord/core/ConfigLoader.java
+++ b/src/main/java/dev/mindiscord/core/ConfigLoader.java
@@ -1,43 +1,193 @@
 package dev.mindiscord.core;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.LinkedHashMap;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hjson.JsonValue;
+import org.hjson.Stringify;
 
-public final class ConfigLoader {
+/** Loads {@link Config} from disk and watches for changes. */
+public final class ConfigLoader implements AutoCloseable {
+  private static final Logger LOGGER = LogManager.getLogger("MinDiscord/Config");
+
   private static final Path LIVE = Path.of("config/mindiscord.json5");
   private static final Path EXAMPLE = Path.of("config/mindiscord.json5.example");
 
-  public static Config loadOrCreate() {
+  private final ObjectMapper mapper;
+  private final ExecutorService watcherExecutor;
+  private final CopyOnWriteArrayList<Consumer<Config>> listeners = new CopyOnWriteArrayList<>();
+  private final MinCoreBridge bridge;
+
+  private volatile Config current;
+  private volatile boolean closed;
+
+  public ConfigLoader(MinCoreBridge bridge) {
+    this.bridge = bridge;
+    this.mapper = new ObjectMapper()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    this.watcherExecutor = Executors.newSingleThreadExecutor(r -> {
+      Thread t = new Thread(r, "MinDiscord-ConfigWatcher");
+      t.setDaemon(true);
+      return t;
+    });
+    ensureExampleConfig();
+    this.current = loadConfig();
+    startWatcher();
+  }
+
+  public Config current() { return current; }
+
+  public void addListener(Consumer<Config> listener) {
+    Objects.requireNonNull(listener, "listener");
+    listeners.add(listener);
+    listener.accept(current);
+  }
+
+  private void ensureExampleConfig() {
     try {
-      if (!Files.exists(EXAMPLE)) {
-        Files.createDirectories(EXAMPLE.getParent());
-        String ex = """{
-  mode: "webhook",
-  routes: {
-    default:            "https://discord.com/api/webhooks/GGGG/HHH",
-    eventAnnouncements: "env:MINDISCORD_WEBHOOK_ANNOUNCE",
-    eventStarts:        "https://discord.com/api/webhooks/AAAA/BBB",
-    eventWinners:       "https://discord.com/api/webhooks/CCCC/DDD",
-    rareDrops:          "https://discord.com/api/webhooks/EEEE/FFF"
-  },
-  defaults: { username: "MinDiscord", avatarUrl: "" },
-  queue: { maxSize: 2000, onOverflow: "dropOldest" },
-  retry: { maxAttempts: 6, baseDelayMs: 500, maxDelayMs: 15000, jitter: true },
-  ratelimit: { perRouteBurst: 10, perRouteRefillPerSec: 5 },
-  log: { level: "INFO", json: false }
-}
-""";
-        Files.writeString(EXAMPLE, ex, StandardCharsets.UTF_8);
+      if (Files.exists(EXAMPLE)) {
+        return;
       }
-      Config cfg = new Config();
-      cfg.routes = new LinkedHashMap<>();
-      cfg.routes.put("default", "https://discord.com/api/webhooks/GGGG/HHH");
-      return cfg;
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+      Files.createDirectories(EXAMPLE.getParent());
+      Runnable writeExample = () -> {
+        try {
+          Files.writeString(EXAMPLE, exampleContents(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+          throw new UncheckedIOException(e);
+        }
+      };
+      if (!bridge.tryWithAdvisoryLock("mindiscord:init", writeExample)) {
+        // Could not acquire lock (maybe another node); best-effort write without lock.
+        writeExample.run();
+      }
+      if (!Files.exists(LIVE)) {
+        Files.copy(EXAMPLE, LIVE, StandardCopyOption.REPLACE_EXISTING);
+      }
+    } catch (IOException | UncheckedIOException e) {
+      throw new RuntimeException("Failed to create example config", e);
     }
+  }
+
+  private Config loadConfig() {
+    try {
+      if (!Files.exists(LIVE)) {
+        LOGGER.warn("mindiscord.json5 missing; using defaults");
+        return Config.defaultConfig();
+      }
+      String raw = Files.readString(LIVE, StandardCharsets.UTF_8);
+      String json = JsonValue.readHjson(raw).toString(Stringify.PLAIN);
+      Config.Raw parsed = mapper.readValue(json, Config.Raw.class);
+      Config cfg = Config.fromRaw(parsed);
+      if (cfg.routes().isEmpty()) {
+        LOGGER.warn("No routes configured; Discord sends will fail until configured");
+      }
+      return cfg;
+    } catch (IOException | RuntimeException e) {
+      LOGGER.error("Failed to load mindiscord.json5: {}", e.toString());
+      if (current != null) {
+        LOGGER.warn("Retaining previous configuration due to load failure");
+        return current;
+      }
+      throw new RuntimeException("No valid configuration available", e);
+    }
+  }
+
+  private void startWatcher() {
+    watcherExecutor.execute(() -> {
+      try (WatchService watcher = FileSystems.getDefault().newWatchService()) {
+        Path dir = LIVE.getParent();
+        if (dir == null) {
+          return;
+        }
+        dir.register(watcher, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_MODIFY);
+        Instant lastReload = Instant.EPOCH;
+        while (!closed) {
+          WatchKey key = watcher.poll(500, TimeUnit.MILLISECONDS);
+          if (key == null) {
+            continue;
+          }
+          boolean relevant = false;
+          for (WatchEvent<?> event : key.pollEvents()) {
+            Object ctx = event.context();
+            if (ctx instanceof Path path && path.getFileName().equals(LIVE.getFileName())) {
+              relevant = true;
+            }
+          }
+          key.reset();
+          if (relevant) {
+            Instant now = Instant.now();
+            if (now.minusMillis(150).isAfter(lastReload)) {
+              reload();
+              lastReload = now;
+            }
+          }
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } catch (IOException e) {
+        LOGGER.error("Config watcher failed: {}", e.toString());
+      }
+    });
+  }
+
+  private void reload() {
+    Config cfg = loadConfig();
+    if (cfg == current) {
+      return;
+    }
+    current = cfg;
+    for (Consumer<Config> listener : listeners) {
+      try {
+        listener.accept(cfg);
+      } catch (RuntimeException e) {
+        LOGGER.error("Config listener threw: {}", e.toString());
+      }
+    }
+    LOGGER.info("Reloaded mindiscord.json5 ({} routes)", cfg.routes().size());
+  }
+
+  private static String exampleContents() {
+    return """
+        {
+          mode: "webhook",
+          routes: {
+            default:            "https://discord.com/api/webhooks/GGGG/HHH",
+            eventAnnouncements: "env:MINDISCORD_WEBHOOK_ANNOUNCE",
+            eventStarts:        "https://discord.com/api/webhooks/AAAA/BBB",
+            eventWinners:       "https://discord.com/api/webhooks/CCCC/DDD",
+            rareDrops:          "https://discord.com/api/webhooks/EEEE/FFF"
+          },
+          defaults: { username: "MinDiscord", avatarUrl: "" },
+          queue: { maxSize: 2000, onOverflow: "dropOldest" },
+          retry: { maxAttempts: 6, baseDelayMs: 500, maxDelayMs: 15000, jitter: true },
+          ratelimit: { perRouteBurst: 10, perRouteRefillPerSec: 5 },
+          log: { level: "INFO", json: false }
+        }
+        """;
+  }
+
+  @Override
+  public void close() {
+    closed = true;
+    watcherExecutor.shutdownNow();
   }
 }

--- a/src/main/java/dev/mindiscord/core/Diagnostics.java
+++ b/src/main/java/dev/mindiscord/core/Diagnostics.java
@@ -1,0 +1,54 @@
+package dev.mindiscord.core;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class Diagnostics {
+  private final ConcurrentHashMap<String, RouteState> states = new ConcurrentHashMap<>();
+
+  void recordSuccess(String route, Instant when, String message) {
+    states.compute(route, (key, state) -> {
+      RouteState s = state != null ? state : new RouteState();
+      s.lastSuccess = when;
+      s.lastMessage = message;
+      s.lastFailure = null;
+      s.lastFailureCode = null;
+      return s;
+    });
+  }
+
+  void recordFailure(String route, Instant when, String code, String message) {
+    states.compute(route, (key, state) -> {
+      RouteState s = state != null ? state : new RouteState();
+      s.lastFailure = when;
+      s.lastFailureCode = code;
+      s.lastMessage = message;
+      return s;
+    });
+  }
+
+  Map<String, RouteSnapshot> snapshot() {
+    Map<String, RouteSnapshot> copy = new LinkedHashMap<>();
+    states.entrySet().stream()
+        .sorted(Map.Entry.comparingByKey())
+        .forEach(entry -> {
+          RouteState state = entry.getValue();
+          copy.put(
+              entry.getKey(),
+              new RouteSnapshot(state.lastSuccess, state.lastFailure, state.lastFailureCode, state.lastMessage));
+        });
+    return copy;
+  }
+
+  static final class RouteState {
+    volatile Instant lastSuccess;
+    volatile Instant lastFailure;
+    volatile String lastFailureCode;
+    volatile String lastMessage;
+  }
+
+  public record RouteSnapshot(
+      Instant lastSuccess, Instant lastFailure, String lastFailureCode, String lastMessage) {}
+}

--- a/src/main/java/dev/mindiscord/core/DispatchQueue.java
+++ b/src/main/java/dev/mindiscord/core/DispatchQueue.java
@@ -1,0 +1,125 @@
+package dev.mindiscord.core;
+
+import dev.mindiscord.core.Config.QueueOverflowPolicy;
+import java.util.ArrayDeque;
+import java.util.Objects;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/** Bounded queue with configurable overflow policy. */
+final class DispatchQueue {
+  private final ReentrantLock lock = new ReentrantLock();
+  private final Condition notEmpty = lock.newCondition();
+  private final ArrayDeque<PendingRequest> deque = new ArrayDeque<>();
+
+  private volatile int maxSize = 2000;
+  private volatile QueueOverflowPolicy overflowPolicy = QueueOverflowPolicy.DROP_OLDEST;
+  private volatile boolean closed;
+
+  void configure(int maxSize, QueueOverflowPolicy policy) {
+    Objects.requireNonNull(policy, "policy");
+    lock.lock();
+    try {
+      this.maxSize = maxSize;
+      this.overflowPolicy = policy;
+      while (deque.size() > maxSize) {
+        PendingRequest dropped = deque.poll();
+        if (dropped != null) {
+          dropped.completeQueueFull();
+        }
+      }
+      if (!deque.isEmpty()) {
+        notEmpty.signalAll();
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  QueuePushResult enqueue(PendingRequest request) {
+    lock.lock();
+    try {
+      if (closed) {
+        return QueuePushResult.rejected();
+      }
+      if (deque.size() >= maxSize) {
+        return switch (overflowPolicy) {
+          case DROP_OLDEST -> {
+            PendingRequest dropped = deque.poll();
+            deque.add(request);
+            notEmpty.signal();
+            yield QueuePushResult.enqueuedWithDrop(dropped);
+          }
+          case DROP_NEWEST, REJECT -> QueuePushResult.rejected();
+        };
+      }
+      deque.add(request);
+      notEmpty.signal();
+      return QueuePushResult.enqueued();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  PendingRequest take() throws InterruptedException {
+    lock.lock();
+    try {
+      while (deque.isEmpty()) {
+        if (closed) {
+          return null;
+        }
+        notEmpty.await();
+      }
+      return deque.poll();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  int size() {
+    lock.lock();
+    try {
+      return deque.size();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  void close() {
+    lock.lock();
+    try {
+      closed = true;
+      for (PendingRequest pending : deque) {
+        pending.completeQueueFull();
+      }
+      deque.clear();
+      notEmpty.signalAll();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  static final class QueuePushResult {
+    enum State { ENQUEUED, REJECTED }
+
+    private final State state;
+    private final PendingRequest dropped;
+
+    private QueuePushResult(State state, PendingRequest dropped) {
+      this.state = state;
+      this.dropped = dropped;
+    }
+
+    static QueuePushResult enqueued() { return new QueuePushResult(State.ENQUEUED, null); }
+
+    static QueuePushResult enqueuedWithDrop(PendingRequest dropped) {
+      return new QueuePushResult(State.ENQUEUED, dropped);
+    }
+
+    static QueuePushResult rejected() { return new QueuePushResult(State.REJECTED, null); }
+
+    boolean isEnqueued() { return state == State.ENQUEUED; }
+
+    PendingRequest dropped() { return dropped; }
+  }
+}

--- a/src/main/java/dev/mindiscord/core/MinCoreBridge.java
+++ b/src/main/java/dev/mindiscord/core/MinCoreBridge.java
@@ -1,0 +1,276 @@
+package dev.mindiscord.core;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/** Reflection-based bridge to MinCore optional APIs. */
+public final class MinCoreBridge {
+  private static final Logger LOGGER = LogManager.getLogger("MinDiscord/MinCore");
+
+  private final Class<?> apiClass;
+  private final Method ledgerMethod;
+  private final Method databaseMethod;
+  private final Method ledgerLogMethod;
+  private final Class<?> extensionDatabaseClass;
+  private final Method tryAdvisoryLockMethod;
+  private final Method releaseAdvisoryLockMethod;
+  private final Method withRetryMethod;
+  private final Method borrowConnectionMethod;
+  private final Class<?> sqlSupplierClass;
+
+  public MinCoreBridge() {
+    Class<?> api;
+    Method ledger;
+    Method database;
+    Method ledgerLog;
+    Class<?> extDb;
+    Method tryLock;
+    Method releaseLock;
+    Method withRetry;
+    Method borrow;
+    Class<?> sqlSupplier;
+    try {
+      api = Class.forName("dev.mincore.api.MinCoreApi");
+      ledger = api.getMethod("ledger");
+      database = api.getMethod("database");
+      Class<?> ledgerType = Class.forName("dev.mincore.api.Ledger");
+      ledgerLog = ledgerType.getMethod(
+          "log",
+          String.class,
+          String.class,
+          UUID.class,
+          UUID.class,
+          long.class,
+          String.class,
+          boolean.class,
+          String.class,
+          String.class,
+          String.class,
+          String.class);
+      extDb = Class.forName("dev.mincore.api.storage.ExtensionDatabase");
+      tryLock = extDb.getMethod("tryAdvisoryLock", String.class);
+      releaseLock = extDb.getMethod("releaseAdvisoryLock", String.class);
+      withRetry = extDb.getMethod(
+          "withRetry", Class.forName("dev.mincore.api.storage.ExtensionDatabase$SQLSupplier"));
+      borrow = extDb.getMethod("borrowConnection");
+      sqlSupplier = Class.forName("dev.mincore.api.storage.ExtensionDatabase$SQLSupplier");
+    } catch (ClassNotFoundException | NoSuchMethodException e) {
+      api = null;
+      ledger = null;
+      database = null;
+      ledgerLog = null;
+      extDb = null;
+      tryLock = null;
+      releaseLock = null;
+      withRetry = null;
+      borrow = null;
+      sqlSupplier = null;
+      LOGGER.warn("MinCore API not present; ledger and stats disabled");
+    }
+    this.apiClass = api;
+    this.ledgerMethod = ledger;
+    this.databaseMethod = database;
+    this.ledgerLogMethod = ledgerLog;
+    this.extensionDatabaseClass = extDb;
+    this.tryAdvisoryLockMethod = tryLock;
+    this.releaseAdvisoryLockMethod = releaseLock;
+    this.withRetryMethod = withRetry;
+    this.borrowConnectionMethod = borrow;
+    this.sqlSupplierClass = sqlSupplier;
+  }
+
+  public boolean available() { return apiClass != null; }
+
+  public boolean tryWithAdvisoryLock(String name, Runnable task) {
+    Objects.requireNonNull(name, "name");
+    Objects.requireNonNull(task, "task");
+    if (!available() || databaseMethod == null || tryAdvisoryLockMethod == null) {
+      task.run();
+      return true;
+    }
+    Object db = database();
+    if (db == null) {
+      task.run();
+      return true;
+    }
+    boolean acquired = false;
+    try {
+      acquired = Boolean.TRUE.equals(tryAdvisoryLockMethod.invoke(db, name));
+      if (acquired) {
+        task.run();
+      }
+      return acquired;
+    } catch (ReflectiveOperationException e) {
+      LOGGER.warn("Failed to use advisory lock {}: {}", name, e.toString());
+      task.run();
+      return false;
+    } finally {
+      if (acquired && releaseAdvisoryLockMethod != null) {
+        try {
+          releaseAdvisoryLockMethod.invoke(db, name);
+        } catch (ReflectiveOperationException e) {
+          LOGGER.warn("Failed to release advisory lock {}: {}", name, e.toString());
+        }
+      }
+    }
+  }
+
+  public void logLedger(
+      String reason,
+      boolean ok,
+      String code,
+      String requestId,
+      String route,
+      String requestedRoute,
+      int payloadBytes,
+      int embeds) {
+    if (ledgerMethod == null || ledgerLogMethod == null) {
+      return;
+    }
+    try {
+      Object ledger = ledgerMethod.invoke(null);
+      if (ledger == null) {
+        return;
+      }
+      String extra = String.format(
+          "{\"route\":\"%s\",\"routeRequested\":%s,\"payloadBytes\":%d,\"embeds\":%d}",
+          route,
+          requestedRoute != null ? "\"" + requestedRoute + "\"" : "null",
+          payloadBytes,
+          embeds);
+      if (extra.length() > 512) {
+        extra = extra.substring(0, 512);
+      }
+      ledgerLogMethod.invoke(
+          ledger,
+          "mindiscord",
+          "announce",
+          null,
+          null,
+          0L,
+          reason,
+          ok,
+          code,
+          "mindiscord",
+          requestId != null ? "send:" + requestId : null,
+          extra);
+    } catch (ReflectiveOperationException e) {
+      LOGGER.warn("Failed to log to MinCore ledger: {}", e.toString());
+    }
+  }
+
+  public void withDatabase(java.util.function.Consumer<Object> consumer) {
+    if (databaseMethod == null || extensionDatabaseClass == null) {
+      return;
+    }
+    Object db = database();
+    if (db == null) {
+      return;
+    }
+    consumer.accept(db);
+  }
+
+  public void ensureStatsTable(Object db, AtomicBoolean ensured) throws Exception {
+    if (ensured.get()) {
+      return;
+    }
+    if (borrowConnectionMethod == null) {
+      return;
+    }
+    executeWithRetry(db, () -> {
+      try (Connection conn = (Connection) borrowConnectionMethod.invoke(db);
+          PreparedStatement ps =
+              conn.prepareStatement(
+                  "create table if not exists mindiscord_stats ("
+                      + "route varchar(64) not null,"
+                      + "day date not null,"
+                      + "sent int unsigned not null default 0,"
+                      + "failed int unsigned not null default 0,"
+                      + "primary key(route, day)) engine=InnoDB default charset=utf8mb4 collate=utf8mb4_unicode_ci")) {
+        ps.executeUpdate();
+      }
+      ensured.set(true);
+      return null;
+    });
+  }
+
+  public void updateStats(Object db, String route, boolean success) throws Exception {
+    if (borrowConnectionMethod == null) {
+      return;
+    }
+    executeWithRetry(db, () -> {
+      LocalDate day = LocalDate.now(ZoneOffset.UTC);
+      String sql =
+          "insert into mindiscord_stats(route, day, sent, failed) values(?,?,?,?) "
+              + "on duplicate key update sent = sent + ?, failed = failed + ?";
+      try (Connection conn = (Connection) borrowConnectionMethod.invoke(db);
+          PreparedStatement ps = conn.prepareStatement(sql)) {
+        ps.setString(1, route);
+        ps.setObject(2, day);
+        if (success) {
+          ps.setInt(3, 1);
+          ps.setInt(4, 0);
+          ps.setInt(5, 1);
+          ps.setInt(6, 0);
+        } else {
+          ps.setInt(3, 0);
+          ps.setInt(4, 1);
+          ps.setInt(5, 0);
+          ps.setInt(6, 1);
+        }
+        ps.executeUpdate();
+      }
+      return null;
+    });
+  }
+
+  private Object database() {
+    if (databaseMethod == null) {
+      return null;
+    }
+    try {
+      return databaseMethod.invoke(null);
+    } catch (ReflectiveOperationException e) {
+      LOGGER.warn("MinCoreApi.database() failed: {}", e.toString());
+      return null;
+    }
+  }
+
+  private Object executeWithRetry(Object db, SqlCallable action) throws Exception {
+    if (withRetryMethod == null || sqlSupplierClass == null) {
+      return action.call();
+    }
+    InvocationHandler handler = (proxy, method, args) -> {
+      if ("get".equals(method.getName())) {
+        return action.call();
+      }
+      throw new UnsupportedOperationException(method.getName());
+    };
+    Object supplier = Proxy.newProxyInstance(
+        sqlSupplierClass.getClassLoader(), new Class[] {sqlSupplierClass}, handler);
+    try {
+      return withRetryMethod.invoke(db, supplier);
+    } catch (ReflectiveOperationException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof Exception ex) {
+        throw ex;
+      }
+      throw e;
+    }
+  }
+
+  @FunctionalInterface
+  interface SqlCallable {
+    Object call() throws Exception;
+  }
+}

--- a/src/main/java/dev/mindiscord/core/MinDiscordRuntime.java
+++ b/src/main/java/dev/mindiscord/core/MinDiscordRuntime.java
@@ -52,6 +52,10 @@ public final class MinDiscordRuntime implements AutoCloseable {
 
   public MinCoreBridge bridge() { return bridge; }
 
+  public Config config() {
+    return configLoader.current();
+  }
+
   @Override
   public void close() {
     bus.close();

--- a/src/main/java/dev/mindiscord/core/MinDiscordRuntime.java
+++ b/src/main/java/dev/mindiscord/core/MinDiscordRuntime.java
@@ -1,0 +1,61 @@
+package dev.mindiscord.core;
+
+import dev.mindiscord.api.AnnounceBus;
+import java.util.List;
+import java.util.Objects;
+public final class MinDiscordRuntime implements AutoCloseable {
+  private static volatile MinDiscordRuntime INSTANCE;
+
+  private final MinCoreBridge bridge = new MinCoreBridge();
+  private final ConfigLoader configLoader;
+  private final Router router = new Router();
+  private final DispatchQueue queue = new DispatchQueue();
+  private final WebhookTransport transport = new WebhookTransport();
+  private final RateLimiterRegistry rateLimiter = new RateLimiterRegistry();
+  private final StatsStore statsStore = new StatsStore(bridge);
+  private final TimeSource timeSource = new SystemTimeSource();
+  private final Sleeper sleeper = new ThreadSleeper();
+  private final AnnounceBusImpl bus;
+
+  private MinDiscordRuntime() {
+    this.configLoader = new ConfigLoader(bridge);
+    Config initial = configLoader.current();
+    this.bus =
+        new AnnounceBusImpl(
+            router,
+            queue,
+            transport,
+            rateLimiter,
+            statsStore,
+            bridge,
+            timeSource,
+            sleeper,
+            initial);
+    this.configLoader.addListener(bus::applyConfig);
+  }
+
+  public static MinDiscordRuntime init() {
+    MinDiscordRuntime runtime = new MinDiscordRuntime();
+    INSTANCE = runtime;
+    return runtime;
+  }
+
+  public static MinDiscordRuntime instance() {
+    return Objects.requireNonNull(INSTANCE, "MinDiscord runtime not initialized");
+  }
+
+  public AnnounceBus bus() { return bus; }
+
+  public AnnounceBusImpl.DiagnosticsSnapshot diagnostics() { return bus.diagnostics(); }
+
+  public List<Router.RouteInfo> routes() { return bus.routes(); }
+
+  public MinCoreBridge bridge() { return bridge; }
+
+  @Override
+  public void close() {
+    bus.close();
+    configLoader.close();
+  }
+
+}

--- a/src/main/java/dev/mindiscord/core/PendingRequest.java
+++ b/src/main/java/dev/mindiscord/core/PendingRequest.java
@@ -1,0 +1,45 @@
+package dev.mindiscord.core;
+
+import dev.mindiscord.api.SendResult;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+final class PendingRequest {
+  final UUID requestId;
+  final String requestedRoute;
+  final String resolvedRoute;
+  final String url;
+  final String jsonPayload;
+  final int payloadBytes;
+  final int embedCount;
+  final boolean fallback;
+  final CompletableFuture<SendResult> future;
+  final Router.RouteResolution resolution;
+  final Instant enqueuedAt;
+
+  PendingRequest(
+      UUID requestId,
+      Router.RouteResolution resolution,
+      String jsonPayload,
+      int payloadBytes,
+      int embedCount,
+      CompletableFuture<SendResult> future,
+      Instant enqueuedAt) {
+    this.requestId = requestId;
+    this.requestedRoute = resolution.requestedRoute();
+    this.resolvedRoute = resolution.resolvedRoute();
+    this.url = resolution.url();
+    this.jsonPayload = jsonPayload;
+    this.payloadBytes = payloadBytes;
+    this.embedCount = embedCount;
+    this.fallback = resolution.status() == Router.Status.FALLBACK;
+    this.future = future;
+    this.resolution = resolution;
+    this.enqueuedAt = enqueuedAt;
+  }
+
+  void completeQueueFull() {
+    future.complete(new SendResult(false, "QUEUE_FULL", "Queue full", requestId.toString()));
+  }
+}

--- a/src/main/java/dev/mindiscord/core/RateLimiterRegistry.java
+++ b/src/main/java/dev/mindiscord/core/RateLimiterRegistry.java
@@ -1,0 +1,71 @@
+package dev.mindiscord.core;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+final class RateLimiterRegistry {
+  private final Map<String, TokenBucket> buckets = new ConcurrentHashMap<>();
+  private volatile int burst = 10;
+  private volatile int refillPerSec = 5;
+
+  void configure(int burst, int refillPerSec) {
+    this.burst = burst;
+    this.refillPerSec = refillPerSec;
+    buckets.values().forEach(bucket -> bucket.configure(burst, refillPerSec));
+  }
+
+  Duration acquire(String key, TimeSource timeSource) {
+    TokenBucket bucket = buckets.computeIfAbsent(key, k -> new TokenBucket(burst, refillPerSec, timeSource));
+    return bucket.acquire(timeSource);
+  }
+
+  private static final class TokenBucket {
+    private volatile int capacity;
+    private volatile int refillPerSec;
+    private double tokens;
+    private long lastCheck;
+
+    TokenBucket(int capacity, int refillPerSec, TimeSource timeSource) {
+      this.capacity = capacity;
+      this.refillPerSec = refillPerSec;
+      this.tokens = capacity;
+      this.lastCheck = timeSource.nanoTime();
+    }
+
+    synchronized Duration acquire(TimeSource timeSource) {
+      long now = timeSource.nanoTime();
+      refill(now);
+      if (tokens >= 1.0) {
+        tokens -= 1.0;
+        return Duration.ZERO;
+      }
+      double needed = 1.0 - tokens;
+      double seconds = needed / Math.max(1, refillPerSec);
+      long nanos = (long) Math.ceil(seconds * 1_000_000_000L);
+      tokens = Math.max(-capacity, tokens - 1.0);
+      return Duration.ofNanos(Math.max(0, nanos));
+    }
+
+    synchronized void configure(int capacity, int refillPerSec) {
+      this.capacity = capacity;
+      this.refillPerSec = refillPerSec;
+      if (tokens > capacity) {
+        tokens = capacity;
+      }
+      if (tokens < -capacity) {
+        tokens = -capacity;
+      }
+    }
+
+    private void refill(long now) {
+      long elapsed = Math.max(0, now - lastCheck);
+      if (elapsed <= 0) {
+        return;
+      }
+      double seconds = elapsed / 1_000_000_000d;
+      tokens = Math.min(capacity, tokens + seconds * refillPerSec);
+      lastCheck = now;
+    }
+  }
+}

--- a/src/main/java/dev/mindiscord/core/Router.java
+++ b/src/main/java/dev/mindiscord/core/Router.java
@@ -1,23 +1,121 @@
 package dev.mindiscord.core;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 
+/** Resolves logical route names to webhook targets. */
 public final class Router {
-  private volatile Map<String,String> routes;
-  public Router(Config cfg) { this.routes = cfg.routes; }
-  public String resolve(String route) {
-    if (route == null || route.isBlank()) route = "default";
-    String url = routes.get(route);
-    if (url == null) {
-      // Fallback to default if present
-      return routes.get("default");
-    }
-    if (url.startsWith("env:")) {
-      String env = url.substring(4);
-      String v = System.getenv(env);
-      return v;
-    }
-    return url;
+  private final AtomicReference<RouteTable> table = new AtomicReference<>(RouteTable.empty());
+
+  public void update(Config config) {
+    table.set(RouteTable.from(config));
   }
+
+  public RouteResolution resolve(String requestedRoute) {
+    return table.get().resolve(requestedRoute);
+  }
+
+  public List<RouteInfo> snapshot() { return table.get().snapshot(); }
+
+  private record RouteTable(
+      Map<String, Config.RouteDefinition> routes,
+      Config.RouteDefinition defaultRoute) {
+
+    static RouteTable empty() {
+      return new RouteTable(Map.of(), null);
+    }
+
+    static RouteTable from(Config config) {
+      Map<String, Config.RouteDefinition> copy = new LinkedHashMap<>(config.routes());
+      return new RouteTable(copy, copy.get("default"));
+    }
+
+    RouteResolution resolve(String requested) {
+      String normalized = requested;
+      if (normalized == null || normalized.isBlank()) {
+        normalized = "default";
+      }
+      Config.RouteDefinition target = routes.get(normalized);
+      boolean fallback = false;
+      if (target == null && defaultRoute != null) {
+        target = defaultRoute;
+        fallback = !"default".equals(normalized);
+      }
+      if (target == null) {
+        return new RouteResolution(
+            normalized,
+            null,
+            null,
+            Status.NO_ROUTE,
+            false,
+            null,
+            null,
+            false);
+      }
+      String resolved = resolveTarget(target);
+      if (resolved == null || resolved.isBlank()) {
+        Status status = target.environment() ? Status.ENV_MISSING : Status.NO_ROUTE;
+        return new RouteResolution(
+            normalized,
+            target.name(),
+            null,
+            status,
+            target.environment(),
+            target.envVariable(),
+            target.rawTarget(),
+            fallback);
+      }
+      return new RouteResolution(
+          normalized,
+          target.name(),
+          resolved,
+          fallback ? Status.FALLBACK : Status.OK,
+          target.environment(),
+          target.envVariable(),
+          target.rawTarget(),
+          fallback);
+    }
+
+    private static String resolveTarget(Config.RouteDefinition def) {
+      if (!def.environment()) {
+        return def.rawTarget();
+      }
+      return System.getenv(def.envVariable());
+    }
+
+    List<RouteInfo> snapshot() {
+      List<RouteInfo> list = new ArrayList<>();
+      for (Config.RouteDefinition def : routes.values()) {
+        String resolved = def.environment() ? System.getenv(def.envVariable()) : def.rawTarget();
+        list.add(
+            new RouteInfo(
+                def.name(),
+                def.rawTarget(),
+                def.environment(),
+                def.envVariable(),
+                resolved != null && !resolved.isBlank()));
+      }
+      return list;
+    }
+  }
+
+  public record RouteInfo(
+      String name, String rawTarget, boolean environment, String envVariable, boolean available) {}
+
+  public record RouteResolution(
+      String requestedRoute,
+      String resolvedRoute,
+      String url,
+      Status status,
+      boolean environment,
+      String envVariable,
+      String rawTarget,
+      boolean fallback) {
+    public boolean ok() { return status == Status.OK || status == Status.FALLBACK; }
+  }
+
+  public enum Status { OK, FALLBACK, NO_ROUTE, ENV_MISSING }
 }

--- a/src/main/java/dev/mindiscord/core/Sleeper.java
+++ b/src/main/java/dev/mindiscord/core/Sleeper.java
@@ -1,0 +1,7 @@
+package dev.mindiscord.core;
+
+import java.time.Duration;
+
+interface Sleeper {
+  void sleep(Duration duration) throws InterruptedException;
+}

--- a/src/main/java/dev/mindiscord/core/StatsStore.java
+++ b/src/main/java/dev/mindiscord/core/StatsStore.java
@@ -1,0 +1,30 @@
+package dev.mindiscord.core;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+final class StatsStore {
+  private static final Logger LOGGER = LogManager.getLogger("MinDiscord/Stats");
+
+  private final MinCoreBridge bridge;
+  private final AtomicBoolean ensured = new AtomicBoolean();
+
+  StatsStore(MinCoreBridge bridge) {
+    this.bridge = bridge;
+  }
+
+  void record(String route, boolean success) {
+    if (!bridge.available()) {
+      return;
+    }
+    bridge.withDatabase(db -> {
+      try {
+        bridge.ensureStatsTable(db, ensured);
+        bridge.updateStats(db, route, success);
+      } catch (Exception e) {
+        LOGGER.debug("Failed to update stats: {}", e.toString());
+      }
+    });
+  }
+}

--- a/src/main/java/dev/mindiscord/core/SystemTimeSource.java
+++ b/src/main/java/dev/mindiscord/core/SystemTimeSource.java
@@ -1,0 +1,9 @@
+package dev.mindiscord.core;
+
+import java.time.Instant;
+
+final class SystemTimeSource implements TimeSource {
+  @Override public Instant now() { return Instant.now(); }
+
+  @Override public long nanoTime() { return System.nanoTime(); }
+}

--- a/src/main/java/dev/mindiscord/core/ThreadSleeper.java
+++ b/src/main/java/dev/mindiscord/core/ThreadSleeper.java
@@ -1,0 +1,15 @@
+package dev.mindiscord.core;
+
+import java.time.Duration;
+
+final class ThreadSleeper implements Sleeper {
+  @Override
+  public void sleep(Duration duration) throws InterruptedException {
+    if (duration.isZero() || duration.isNegative()) {
+      return;
+    }
+    long millis = duration.toMillis();
+    int nanos = (int) (duration.toNanos() - millis * 1_000_000L);
+    Thread.sleep(millis, Math.max(0, nanos));
+  }
+}

--- a/src/main/java/dev/mindiscord/core/TimeSource.java
+++ b/src/main/java/dev/mindiscord/core/TimeSource.java
@@ -1,0 +1,9 @@
+package dev.mindiscord.core;
+
+import java.time.Instant;
+
+interface TimeSource {
+  Instant now();
+
+  long nanoTime();
+}

--- a/src/main/java/dev/mindiscord/core/WebhookClient.java
+++ b/src/main/java/dev/mindiscord/core/WebhookClient.java
@@ -1,0 +1,5 @@
+package dev.mindiscord.core;
+
+interface WebhookClient {
+  WebhookTransport.TransportResponse postJson(String url, String json);
+}

--- a/src/main/java/dev/mindiscord/core/WebhookClient.java
+++ b/src/main/java/dev/mindiscord/core/WebhookClient.java
@@ -2,4 +2,8 @@ package dev.mindiscord.core;
 
 interface WebhookClient {
   WebhookTransport.TransportResponse postJson(String url, String json);
+
+  default void configure(Config.Transport transport) {
+    // no-op by default
+  }
 }

--- a/src/main/java/dev/mindiscord/core/WebhookTransport.java
+++ b/src/main/java/dev/mindiscord/core/WebhookTransport.java
@@ -6,11 +6,17 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAccessor;
+import java.util.Optional;
 
-public final class WebhookTransport {
-  private final HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(3)).build();
+public final class WebhookTransport implements WebhookClient {
+  private final HttpClient client =
+      HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(3)).build();
 
-  public boolean postJson(String url, String json) {
+  @Override
+  public TransportResponse postJson(String url, String json) {
     try {
       var req = HttpRequest.newBuilder(URI.create(url))
           .header("Content-Type", "application/json")
@@ -18,10 +24,41 @@ public final class WebhookTransport {
           .POST(HttpRequest.BodyPublishers.ofString(json, StandardCharsets.UTF_8))
           .build();
       var resp = client.send(req, HttpResponse.BodyHandlers.discarding());
-      int sc = resp.statusCode();
-      return sc >= 200 && sc < 300;
+      int status = resp.statusCode();
+      Duration retry = parseRetryAfter(resp.headers().firstValue("Retry-After"));
+      return new TransportResponse(status >= 200 && status < 300, status, retry, null);
     } catch (Exception e) {
-      return false;
+      return new TransportResponse(false, -1, null, e);
     }
   }
+
+  private static Duration parseRetryAfter(Optional<String> header) {
+    if (header.isEmpty()) {
+      return null;
+    }
+    String value = header.get().trim();
+    if (value.isEmpty()) {
+      return null;
+    }
+    try {
+      long seconds = Long.parseLong(value);
+      if (seconds < 0) {
+        return null;
+      }
+      return Duration.ofSeconds(seconds);
+    } catch (NumberFormatException ignored) {
+      try {
+        TemporalAccessor parsed = DateTimeFormatter.RFC_1123_DATE_TIME.parse(value);
+        long millis = java.time.Instant.from(parsed).toEpochMilli() - System.currentTimeMillis();
+        if (millis <= 0) {
+          return null;
+        }
+        return Duration.ofMillis(millis);
+      } catch (DateTimeParseException ex) {
+        return null;
+      }
+    }
+  }
+
+  public record TransportResponse(boolean success, int statusCode, Duration retryAfter, Throwable error) {}
 }

--- a/src/main/java/dev/mindiscord/perms/Perms.java
+++ b/src/main/java/dev/mindiscord/perms/Perms.java
@@ -1,0 +1,116 @@
+package dev.mindiscord.perms;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.context.ContextManager;
+import net.luckperms.api.model.user.User;
+import net.luckperms.api.query.QueryOptions;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+/** Permission gateway that prefers MinCore when available, falling back to LuckPerms/Fabric/OP. */
+public final class Perms {
+  @FunctionalInterface
+  interface OpFallback {
+    boolean check(ServerPlayerEntity player, int level);
+  }
+
+  private static final AtomicReference<Method> MINCORE_METHOD = new AtomicReference<>();
+  private static final AtomicBoolean MINCORE_UNAVAILABLE = new AtomicBoolean();
+  private static final OpFallback DEFAULT_FALLBACK =
+      (player, level) -> player != null && player.hasPermissionLevel(level);
+  private static volatile OpFallback opFallback = DEFAULT_FALLBACK;
+
+  private Perms() {}
+
+  public static boolean check(ServerPlayerEntity player, String node, int opLevelFallback) {
+    Method mincore = resolveMinCore();
+    if (mincore != null) {
+      try {
+        Object result = mincore.invoke(null, player, node, opLevelFallback);
+        if (result instanceof Boolean bool) {
+          return bool;
+        }
+      } catch (ReflectiveOperationException e) {
+        // fall back to local gateway when MinCore invocation fails
+      }
+    }
+    Boolean luck = luckPermsCheck(player, node);
+    if (luck != null) {
+      return luck.booleanValue();
+    }
+    Boolean fabric = fabricPermissionsCheck(player, node, opLevelFallback);
+    if (fabric != null) {
+      return fabric.booleanValue();
+    }
+    return opFallback.check(player, opLevelFallback);
+  }
+
+  private static Method resolveMinCore() {
+    Method cached = MINCORE_METHOD.get();
+    if (cached != null || MINCORE_UNAVAILABLE.get()) {
+      return cached;
+    }
+    try {
+      Class<?> gateway = Class.forName("dev.mincore.perms.Perms");
+      Method method = gateway.getMethod("check", ServerPlayerEntity.class, String.class, int.class);
+      MINCORE_METHOD.compareAndSet(null, method);
+      return method;
+    } catch (ClassNotFoundException | NoSuchMethodException e) {
+      MINCORE_UNAVAILABLE.set(true);
+      return null;
+    }
+  }
+
+  private static Boolean luckPermsCheck(ServerPlayerEntity player, String node) {
+    try {
+      LuckPerms api = LuckPermsProvider.get();
+      if (api == null) {
+        return null;
+      }
+      User user = api.getUserManager().getUser(player.getUuid());
+      if (user == null) {
+        return null;
+      }
+      ContextManager contextManager = api.getContextManager();
+      QueryOptions options = contextManager.getQueryOptions(player);
+      if (options == null) {
+        options = contextManager.getStaticQueryOptions();
+      }
+      if (options == null) {
+        return null;
+      }
+      return user.getCachedData().getPermissionData(options).checkPermission(node).asBoolean();
+    } catch (IllegalStateException | NoClassDefFoundError ignored) {
+      return null;
+    }
+  }
+
+  private static Boolean fabricPermissionsCheck(
+      ServerPlayerEntity player, String node, int opLevelFallback) {
+    try {
+      Class<?> permsClass = Class.forName("me.lucko.fabric.api.permissions.v0.Permissions");
+      Class<?> sourceClass =
+          Class.forName("net.minecraft.server.command.ServerCommandSource", false, player.getClass().getClassLoader());
+      Method method = permsClass.getMethod("check", sourceClass, String.class, int.class);
+      Object source = player.getCommandSource();
+      if (source == null) {
+        return null;
+      }
+      Object result = method.invoke(null, source, node, opLevelFallback);
+      return result instanceof Boolean ? (Boolean) result : null;
+    } catch (ReflectiveOperationException | NoClassDefFoundError ignored) {
+      return null;
+    }
+  }
+
+  static void setFallbackForTesting(OpFallback fallback) {
+    opFallback = fallback;
+  }
+
+  static void resetFallbackForTesting() {
+    opFallback = DEFAULT_FALLBACK;
+  }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,5 +14,9 @@
     "fabric-api": "*",
     "mincore": ">=0.2.0"
   },
+  "suggests": {
+    "luckperms": "*",
+    "fabric-permissions-api-v0": "*"
+  },
   "contact": { "sources": "https://github.com/your/repo" }
 }

--- a/src/test/java/dev/mindiscord/commands/MindiscordRoutesCommandTest.java
+++ b/src/test/java/dev/mindiscord/commands/MindiscordRoutesCommandTest.java
@@ -1,0 +1,25 @@
+package dev.mindiscord.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import dev.mindiscord.core.Router;
+import org.junit.jupiter.api.Test;
+
+class MindiscordRoutesCommandTest {
+  @Test
+  void formatRouteRespectsRedactionToggle() {
+    Router.RouteInfo info =
+        new Router.RouteInfo(
+            "default",
+            "https://discord.com/api/webhooks/AAA/BBB",
+            false,
+            null,
+            true);
+
+    String redacted = MindiscordRoutesCommand.formatRoute(info, true);
+    String plain = MindiscordRoutesCommand.formatRoute(info, false);
+
+    assertEquals("https://discord.com/api/webhooks/…", redacted);
+    assertEquals("https://discord.com/api/webhooks/AAA/BBB", plain);
+  }
+}

--- a/src/test/java/dev/mindiscord/core/AnnounceBusImplTest.java
+++ b/src/test/java/dev/mindiscord/core/AnnounceBusImplTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import dev.mindiscord.api.SendResult;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -23,7 +24,11 @@ class AnnounceBusImplTest {
 
   @Test
   void unknownRouteWithoutDefaultReturnsBadRoute() throws Exception {
-    Config cfg = Config.builder().putRoute("known", "https://example/known").build();
+    Config cfg =
+        Config.builder()
+            .announce(new Config.Announce(true, false, List.of("missing", "known")))
+            .putRoute("known", "https://example/known")
+            .build();
     bus = buildBus(cfg, new SuccessTransport());
     SendResult result = bus.send("missing", "hello").get(1, TimeUnit.SECONDS);
     assertFalse(result.ok());
@@ -32,7 +37,11 @@ class AnnounceBusImplTest {
 
   @Test
   void fallbackToDefaultReturnsBadRouteFallback() throws Exception {
-    Config cfg = Config.builder().putRoute("default", "https://example/default").build();
+    Config cfg =
+        Config.builder()
+            .announce(new Config.Announce(true, true, List.of("default", "missing")))
+            .putRoute("default", "https://example/default")
+            .build();
     RecordingTransport transport = new RecordingTransport();
     bus = buildBus(cfg, transport);
     SendResult result = bus.send("missing", "hello").get(1, TimeUnit.SECONDS);
@@ -46,7 +55,7 @@ class AnnounceBusImplTest {
     Config cfg =
         Config.builder()
             .putRoute("default", "https://example/default")
-            .retry(new Config.Retry(2, Duration.ofMillis(1), Duration.ofMillis(2), false))
+            .transport(new Config.Transport(3000, 5000, 2))
             .build();
     FailingTransport transport = new FailingTransport();
     FakeTimeSource time = new FakeTimeSource();
@@ -66,6 +75,45 @@ class AnnounceBusImplTest {
     SendResult result = bus.send("default", "msg").get(1, TimeUnit.SECONDS);
     assertFalse(result.ok());
     assertEquals("GIVE_UP", result.code());
+  }
+
+  @Test
+  void announceDisabledBlocksSend() throws Exception {
+    Config cfg =
+        Config.builder()
+            .announce(new Config.Announce(false, true, List.of("default")))
+            .putRoute("default", "https://example/default")
+            .build();
+    bus = buildBus(cfg, new SuccessTransport());
+    SendResult result = bus.send("default", "test").get(1, TimeUnit.SECONDS);
+    assertFalse(result.ok());
+    assertEquals("DISABLED", result.code());
+  }
+
+  @Test
+  void fallbackDisabledReturnsBadRoute() throws Exception {
+    Config cfg =
+        Config.builder()
+            .announce(new Config.Announce(true, false, List.of("default", "missing")))
+            .putRoute("default", "https://example/default")
+            .build();
+    bus = buildBus(cfg, new SuccessTransport());
+    SendResult result = bus.send("missing", "test").get(1, TimeUnit.SECONDS);
+    assertFalse(result.ok());
+    assertEquals("BAD_ROUTE", result.code());
+  }
+
+  @Test
+  void disallowedRouteReturnsRouteDisabled() throws Exception {
+    Config cfg =
+        Config.builder()
+            .announce(new Config.Announce(true, true, List.of("default")))
+            .putRoute("default", "https://example/default")
+            .build();
+    bus = buildBus(cfg, new SuccessTransport());
+    SendResult result = bus.send("blocked", "test").get(1, TimeUnit.SECONDS);
+    assertFalse(result.ok());
+    assertEquals("ROUTE_DISABLED", result.code());
   }
 
   private AnnounceBusImpl buildBus(Config config, WebhookClient transport) {

--- a/src/test/java/dev/mindiscord/core/AnnounceBusImplTest.java
+++ b/src/test/java/dev/mindiscord/core/AnnounceBusImplTest.java
@@ -1,0 +1,154 @@
+package dev.mindiscord.core;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import dev.mindiscord.api.SendResult;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class AnnounceBusImplTest {
+  private AnnounceBusImpl bus;
+
+  @AfterEach
+  void cleanup() {
+    if (bus != null) {
+      bus.close();
+    }
+  }
+
+  @Test
+  void unknownRouteWithoutDefaultReturnsBadRoute() throws Exception {
+    Config cfg = Config.builder().putRoute("known", "https://example/known").build();
+    bus = buildBus(cfg, new SuccessTransport());
+    SendResult result = bus.send("missing", "hello").get(1, TimeUnit.SECONDS);
+    assertFalse(result.ok());
+    assertEquals("BAD_ROUTE", result.code());
+  }
+
+  @Test
+  void fallbackToDefaultReturnsBadRouteFallback() throws Exception {
+    Config cfg = Config.builder().putRoute("default", "https://example/default").build();
+    RecordingTransport transport = new RecordingTransport();
+    bus = buildBus(cfg, transport);
+    SendResult result = bus.send("missing", "hello").get(1, TimeUnit.SECONDS);
+    assertTrue(result.ok());
+    assertEquals("BAD_ROUTE_FALLBACK", result.code());
+    assertEquals("https://example/default", transport.lastUrl);
+  }
+
+  @Test
+  void retriesGiveUpAfterFailures() throws Exception {
+    Config cfg =
+        Config.builder()
+            .putRoute("default", "https://example/default")
+            .retry(new Config.Retry(2, Duration.ofMillis(1), Duration.ofMillis(2), false))
+            .build();
+    FailingTransport transport = new FailingTransport();
+    FakeTimeSource time = new FakeTimeSource();
+    FakeSleeper sleeper = new FakeSleeper(time);
+    MinCoreBridge bridge = new MinCoreBridge();
+    bus =
+        new AnnounceBusImpl(
+            new Router(),
+            new DispatchQueue(),
+            transport,
+            new RateLimiterRegistry(),
+            new StatsStore(bridge),
+            bridge,
+            time,
+            sleeper,
+            cfg);
+    SendResult result = bus.send("default", "msg").get(1, TimeUnit.SECONDS);
+    assertFalse(result.ok());
+    assertEquals("GIVE_UP", result.code());
+  }
+
+  private AnnounceBusImpl buildBus(Config config, WebhookClient transport) {
+    FakeTimeSource time = new FakeTimeSource();
+    FakeSleeper sleeper = new FakeSleeper(time);
+    Router router = new Router();
+    MinCoreBridge bridge = new MinCoreBridge();
+    AnnounceBusImpl instance =
+        new AnnounceBusImpl(
+            router,
+            new DispatchQueue(),
+            transport,
+            new RateLimiterRegistry(),
+            new StatsStore(bridge),
+            bridge,
+            time,
+            sleeper,
+            config);
+    return instance;
+  }
+
+  private static final class SuccessTransport implements WebhookClient {
+    @Override
+    public WebhookTransport.TransportResponse postJson(String url, String json) {
+      return new WebhookTransport.TransportResponse(true, 204, null, null);
+    }
+  }
+
+  private static final class RecordingTransport implements WebhookClient {
+    volatile String lastUrl;
+
+    @Override
+    public WebhookTransport.TransportResponse postJson(String url, String json) {
+      this.lastUrl = url;
+      return new WebhookTransport.TransportResponse(true, 204, null, null);
+    }
+  }
+
+  private static final class BlockingTransport implements WebhookClient {
+    final CountDownLatch started = new CountDownLatch(1);
+    final CountDownLatch release = new CountDownLatch(1);
+
+    @Override
+    public WebhookTransport.TransportResponse postJson(String url, String json) {
+      started.countDown();
+      try {
+        release.await(1, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      return new WebhookTransport.TransportResponse(true, 204, null, null);
+    }
+  }
+
+  private static final class FailingTransport implements WebhookClient {
+    @Override
+    public WebhookTransport.TransportResponse postJson(String url, String json) {
+      return new WebhookTransport.TransportResponse(false, 500, null, null);
+    }
+  }
+
+  private static final class FakeTimeSource implements TimeSource {
+    private Instant instant = Instant.EPOCH;
+    private long nanos;
+
+    @Override public Instant now() { return instant; }
+
+    @Override public long nanoTime() { return nanos; }
+
+    void advance(Duration duration) {
+      instant = instant.plus(duration);
+      nanos += duration.toNanos();
+    }
+  }
+
+  private static final class FakeSleeper implements Sleeper {
+    private final FakeTimeSource time;
+
+    FakeSleeper(FakeTimeSource time) { this.time = time; }
+
+    @Override
+    public void sleep(Duration duration) throws InterruptedException {
+      time.advance(duration);
+    }
+  }
+}

--- a/src/test/java/dev/mindiscord/core/DispatchQueueTest.java
+++ b/src/test/java/dev/mindiscord/core/DispatchQueueTest.java
@@ -1,0 +1,47 @@
+package dev.mindiscord.core;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import dev.mindiscord.api.SendResult;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+
+class DispatchQueueTest {
+  @Test
+  void rejectPolicyReturnsQueueFull() {
+    DispatchQueue queue = new DispatchQueue();
+    queue.configure(1, Config.QueueOverflowPolicy.REJECT);
+
+    PendingRequest first = request("first");
+    assertTrue(queue.enqueue(first).isEnqueued());
+
+    PendingRequest second = request("second");
+    var result = queue.enqueue(second);
+    assertFalse(result.isEnqueued());
+  }
+
+  @Test
+  void dropOldestReturnsDroppedRequest() {
+    DispatchQueue queue = new DispatchQueue();
+    queue.configure(1, Config.QueueOverflowPolicy.DROP_OLDEST);
+
+    PendingRequest first = request("first");
+    PendingRequest second = request("second");
+
+    assertTrue(queue.enqueue(first).isEnqueued());
+    var result = queue.enqueue(second);
+    assertTrue(result.isEnqueued());
+    assertSame(first, result.dropped());
+    result.dropped().completeQueueFull();
+  }
+
+  private PendingRequest request(String route) {
+    Router.RouteResolution resolution =
+        new Router.RouteResolution(route, route, "https://example", Router.Status.OK, false, null, null, false);
+    CompletableFuture<SendResult> future = new CompletableFuture<>();
+    return new PendingRequest(
+        UUID.randomUUID(), resolution, "{}", 2, 0, future, Instant.EPOCH);
+  }
+}

--- a/src/test/java/dev/mindiscord/core/RateLimiterRegistryTest.java
+++ b/src/test/java/dev/mindiscord/core/RateLimiterRegistryTest.java
@@ -1,0 +1,53 @@
+package dev.mindiscord.core;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class RateLimiterRegistryTest {
+
+  @Test
+  void refillsTokensAfterReportedDelay() {
+    RateLimiterRegistry registry = new RateLimiterRegistry();
+    FakeTimeSource time = new FakeTimeSource();
+    registry.configure(2, 2);
+
+    Duration[] waits = new Duration[4];
+    for (int i = 0; i < waits.length; i++) {
+      waits[i] = registry.acquire("route", time);
+      time.advance(waits[i]);
+    }
+
+    assertEquals(Duration.ZERO, waits[0]);
+    assertEquals(Duration.ZERO, waits[1]);
+    assertEquals(Duration.ofMillis(500), waits[2]);
+    assertEquals(Duration.ofMillis(500), waits[3]);
+
+    time.advance(Duration.ofSeconds(2));
+
+    assertEquals(Duration.ZERO, registry.acquire("route", time));
+    assertEquals(Duration.ZERO, registry.acquire("route", time));
+  }
+
+  private static final class FakeTimeSource implements TimeSource {
+    private Instant instant = Instant.EPOCH;
+    private long nanos;
+
+    @Override
+    public Instant now() {
+      return instant;
+    }
+
+    @Override
+    public long nanoTime() {
+      return nanos;
+    }
+
+    void advance(Duration duration) {
+      instant = instant.plus(duration);
+      nanos += duration.toNanos();
+    }
+  }
+}

--- a/src/test/java/dev/mindiscord/core/RateLimiterRegistryTest.java
+++ b/src/test/java/dev/mindiscord/core/RateLimiterRegistryTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class RateLimiterRegistryTest {
@@ -12,7 +13,10 @@ class RateLimiterRegistryTest {
   void refillsTokensAfterReportedDelay() {
     RateLimiterRegistry registry = new RateLimiterRegistry();
     FakeTimeSource time = new FakeTimeSource();
-    registry.configure(2, 2);
+    registry.configure(
+        new Config.RateLimit(
+            Map.of("default", new Config.RateLimit.Rule(120, 2)),
+            Config.QueueOverflowPolicy.DROP_OLDEST));
 
     Duration[] waits = new Duration[4];
     for (int i = 0; i < waits.length; i++) {

--- a/src/test/java/dev/mindiscord/core/RouterTest.java
+++ b/src/test/java/dev/mindiscord/core/RouterTest.java
@@ -1,39 +1,42 @@
 package dev.mindiscord.core;
 
 import static org.junit.jupiter.api.Assertions.*;
-import java.util.LinkedHashMap;
 import org.junit.jupiter.api.Test;
 
 public class RouterTest {
 
   @Test
   void resolvesDefaultWhenRouteNullOrBlank() {
-    Config cfg = new Config();
-    cfg.routes = new LinkedHashMap<>();
-    cfg.routes.put("default", "http://example/default");
-    Router r = new Router(cfg);
-    assertEquals("http://example/default", r.resolve(null));
-    assertEquals("http://example/default", r.resolve(""));
-    assertEquals("http://example/default", r.resolve("   "));
+    Config cfg =
+        Config.builder().putRoute("default", "http://example/default").build();
+    Router r = new Router();
+    r.update(cfg);
+    assertEquals("http://example/default", r.resolve(null).url());
+    assertEquals("http://example/default", r.resolve("").url());
+    assertEquals("http://example/default", r.resolve("   ").url());
   }
 
   @Test
   void fallsBackToDefaultWhenUnknownRoute() {
-    Config cfg = new Config();
-    cfg.routes = new LinkedHashMap<>();
-    cfg.routes.put("default", "http://example/default");
-    cfg.routes.put("known", "http://example/known");
-    Router r = new Router(cfg);
-    assertEquals("http://example/default", r.resolve("unknown-route"));
-    assertEquals("http://example/known", r.resolve("known"));
+    Config cfg =
+        Config.builder()
+            .putRoute("default", "http://example/default")
+            .putRoute("known", "http://example/known")
+            .build();
+    Router r = new Router();
+    r.update(cfg);
+    assertEquals("http://example/default", r.resolve("unknown-route").url());
+    assertEquals("http://example/known", r.resolve("known").url());
+    assertEquals(Router.Status.FALLBACK, r.resolve("unknown-route").status());
   }
 
   @Test
   void returnsNullWhenUnknownAndNoDefault() {
-    Config cfg = new Config();
-    cfg.routes = new LinkedHashMap<>();
-    cfg.routes.put("known", "http://example/known");
-    Router r = new Router(cfg);
-    assertNull(r.resolve("unknown"));
+    Config cfg = Config.builder().putRoute("known", "http://example/known").build();
+    Router r = new Router();
+    r.update(cfg);
+    Router.RouteResolution res = r.resolve("unknown");
+    assertNull(res.url());
+    assertEquals(Router.Status.NO_ROUTE, res.status());
   }
 }

--- a/src/test/java/dev/mindiscord/core/WebhookTransportTest.java
+++ b/src/test/java/dev/mindiscord/core/WebhookTransportTest.java
@@ -9,12 +9,7 @@ import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -56,19 +51,10 @@ public class WebhookTransportTest {
     var port = server.getAddress().getPort();
     var url = "http://127.0.0.1:" + port + "/api/webhooks/test";
 
-    var client = HttpClient.newBuilder()
-        .connectTimeout(Duration.ofSeconds(3))
-        .build();
-
-    var json = "{\"content\":\"Hello from MinDiscord\"}";
-    var req = HttpRequest.newBuilder(URI.create(url))
-        .timeout(Duration.ofSeconds(5))
-        .header("Content-Type", "application/json")
-        .POST(HttpRequest.BodyPublishers.ofString(json))
-        .build();
-
-    HttpResponse<Void> resp = client.send(req, HttpResponse.BodyHandlers.discarding());
-    assertTrue(resp.statusCode() >= 200 && resp.statusCode() < 300, "Expected 2xx status");
+    WebhookTransport transport = new WebhookTransport();
+    var resp = transport.postJson(url, "{\"content\":\"Hello from MinDiscord\"}");
+    assertTrue(resp.success(), "Expected transport success");
+    assertEquals(204, resp.statusCode());
     assertEquals("/api/webhooks/test", lastPath);
     assertNotNull(lastBody);
     assertTrue(lastBody.contains("\"content\""));

--- a/src/test/java/dev/mindiscord/perms/PermsTest.java
+++ b/src/test/java/dev/mindiscord/perms/PermsTest.java
@@ -1,0 +1,30 @@
+package dev.mindiscord.perms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class PermsTest {
+  @AfterEach
+  void reset() {
+    Perms.resetFallbackForTesting();
+  }
+
+  @Test
+  void fallsBackToOpLevelWhenGatewaysUnavailable() {
+    AtomicInteger levelSeen = new AtomicInteger();
+    Perms.setFallbackForTesting(
+        (player, level) -> {
+          levelSeen.set(level);
+          return true;
+        });
+
+    boolean result = Perms.check(null, "mindiscord.admin", 2);
+
+    assertTrue(result);
+    assertEquals(2, levelSeen.get());
+  }
+}


### PR DESCRIPTION
## Summary
- build the MinDiscord runtime with dispatch queue, rate limiting, retries, and hot-reloadable configuration
- integrate MinCore ledger logging plus optional stats collection and expose Fabric commands for routes, test, and diagnostics
- update documentation and tests covering routing, transport handling, queue overflow, and announce bus behaviors
- fix token bucket accounting in the per-route rate limiter and add regression test coverage

## Testing
- gradle test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d5a38c8b288333853079497805f1c7